### PR TITLE
Add optional `aria-label` prop to `DropdownInput`.

### DIFF
--- a/src/components/Dropdown/DropdownInput.tsx
+++ b/src/components/Dropdown/DropdownInput.tsx
@@ -10,6 +10,7 @@ import { useInputContext } from './InputContext';
 export function DropdownInput(props: {
   className?: string,
   placeholder?: string,
+  ariaLabel?: string,
   onSubmit?: (value: string, index: number, focusedItemData: FocusedItemData | undefined ) => void,
   onFocus?: (value: string) => void,
   onChange?: (value: string) => void,
@@ -18,6 +19,7 @@ export function DropdownInput(props: {
   const {
     className,
     placeholder,
+    ariaLabel,
     onSubmit,
     onFocus,
     onChange,
@@ -79,6 +81,7 @@ export function DropdownInput(props: {
       id={screenReaderUUID && generateDropdownId(screenReaderUUID, -1)}
       aria-describedby={screenReaderUUID}
       aria-activedescendant={screenReaderUUID && generateDropdownId(screenReaderUUID, focusedIndex)}
+      aria-label={ariaLabel}
     />
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -280,6 +280,7 @@ export function SearchBar({
         onSubmit={handleSubmit}
         onFocus={handleInputFocus}
         onChange={handleInputChange}
+        ariaLabel={'Conduct a search'}
       />
     );
   }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -280,7 +280,7 @@ export function SearchBar({
         onSubmit={handleSubmit}
         onFocus={handleInputFocus}
         onChange={handleInputChange}
-        ariaLabel={'Conduct a search'}
+        ariaLabel='Conduct a search'
       />
     );
   }


### PR DESCRIPTION
This prop allows users of `DropdownInput` to optionally add an `aria-label`
to the `input` element. This is especially useful when using the Component
with buttons such as the clear button or the `DropdownSubmitButton`.

J=SLAP-2058
TEST=auto

Verified that Storybook no longer reported WCAG violations for the `SearchBar`.