### PR TITLE
add autocomplete="off" to DropdownInput

### DIFF
--- a/src/components/Dropdown/DropdownInput.tsx
+++ b/src/components/Dropdown/DropdownInput.tsx
@@ -80,7 +80,6 @@ export function DropdownInput(props: {
       onFocus={handleFocus}
       id={screenReaderUUID && generateDropdownId(screenReaderUUID, -1)}
       autoComplete='off'
-      type='text'
       aria-describedby={screenReaderUUID}
       aria-activedescendant={screenReaderUUID && generateDropdownId(screenReaderUUID, focusedIndex)}
       aria-label={ariaLabel}

--- a/src/components/Dropdown/DropdownInput.tsx
+++ b/src/components/Dropdown/DropdownInput.tsx
@@ -79,6 +79,8 @@ export function DropdownInput(props: {
       onKeyDown={handleKeyDown}
       onFocus={handleFocus}
       id={screenReaderUUID && generateDropdownId(screenReaderUUID, -1)}
+      autoComplete='off'
+      type='text'
       aria-describedby={screenReaderUUID}
       aria-activedescendant={screenReaderUUID && generateDropdownId(screenReaderUUID, focusedIndex)}
       aria-label={ariaLabel}


### PR DESCRIPTION
This prevents default browser autocomplete, which generally
corresponds to recently searched items.

J=SLAP-2050
TEST=manual

added name="name" to the DropdownInput's input, since my browser has
autocomplete values saved for that input name. Saw the default browser
autocomplete show up. Added autocomplete="off", saw it disappear.