### PR TITLE
Distribute Tailwind CSS Bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "THIRD-PARTY-NOTICES"
   ],
   "scripts": {
-    "build": "rm -rf lib/** && tsc && npm run api-extractor && npm run generate-docs",
+    "build": "rm -rf lib/** && tsc && npx tailwindcss -o ./lib/bundle.css --minify && npm run api-extractor && npm run generate-docs",
     "dev": "tsc --watch",
     "lint": "eslint .",
     "api-extractor": "api-extractor run --local --verbose",
@@ -123,5 +123,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/yext/answers-react-components.git"
+  },
+  "exports": {
+    ".": "./lib/index.js",
+    "./bundle.css": "./lib/bundle.css"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "THIRD-PARTY-NOTICES"
   ],
   "scripts": {
-    "build": "rm -rf lib/** && tsc && npx tailwindcss -o ./lib/bundle.css --minify && npm run api-extractor && npm run generate-docs",
+    "build": "rm -rf lib/** && tsc && tailwindcss -o ./lib/bundle.css --minify && npm run api-extractor && npm run generate-docs",
     "dev": "tsc --watch",
     "lint": "eslint .",
     "api-extractor": "api-extractor run --local --verbose",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  content: [
+    './lib/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        'primary': 'var(--primary-color, #2563eb)',
+        'primary-light': 'var(--primary-color-light, #dbeafe)',
+        'primary-dark':  'var(--primary-color-dark, #dbeafe)',
+        'neutral': 'var(--neutral-color, #4b5563)',
+        'neutral-light': 'var(--neutral-color-light, #9ca3af)',
+        'neutral-dark': 'var(--neutral-color-dark, #1f2937)'
+      },
+      borderRadius: {
+        cta: 'var(--cta-border-radius, 1rem)'
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms')({
+      strategy: 'class',
+    })
+  ],
+};

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -27,7 +27,7 @@
     },
     "..": {
       "name": "@yext/answers-react-components",
-      "version": "0.1.1-beta.5",
+      "version": "0.1.1-beta.6",
       "dependencies": {
         "@css-modules-theme/core": "^2.3.0",
         "@microsoft/api-documenter": "^7.15.3",
@@ -46,8 +46,8 @@
         "@babel/preset-env": "^7.14.7",
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.14.5",
-        "@percy/cli": "^1.0.0-beta.76",
-        "@percy/storybook": "^4.1.0",
+        "@percy/cli": "^1.0.7",
+        "@percy/storybook": "^4.2.0",
         "@storybook/addon-a11y": "^6.4.20",
         "@storybook/addon-actions": "^6.4.19",
         "@storybook/addon-essentials": "^6.4.19",
@@ -65,7 +65,7 @@
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
-        "@yext/answers-headless-react": "^1.1.0-beta.10",
+        "@yext/answers-headless-react": "^1.1.0-beta.11",
         "@yext/eslint-config-slapshot": "^0.2.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -82,7 +82,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/answers-headless-react": "^1.1.0-beta.10",
+        "@yext/answers-headless-react": "^1.1.0-beta.11",
         "react": "^17.0.2"
       }
     },
@@ -35342,8 +35342,8 @@
         "@css-modules-theme/core": "^2.3.0",
         "@microsoft/api-documenter": "^7.15.3",
         "@microsoft/api-extractor": "^7.19.4",
-        "@percy/cli": "^1.0.0-beta.76",
-        "@percy/storybook": "^4.1.0",
+        "@percy/cli": "^1.0.7",
+        "@percy/storybook": "^4.2.0",
         "@restart/hooks": "^0.4.5",
         "@restart/ui": "^1.0.1",
         "@storybook/addon-a11y": "^6.4.20",
@@ -35365,7 +35365,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
-        "@yext/answers-headless-react": "^1.1.0-beta.10",
+        "@yext/answers-headless-react": "^1.1.0-beta.11",
         "@yext/eslint-config-slapshot": "^0.2.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",


### PR DESCRIPTION
Distribute a Tailwind CSS bundle so that a Tailwind build chain isn't required in order to get the component styling

J=SLAP-2051
TEST=manual

In the test-site, delete the tailwind.config.js file and import `@yext/answers-react-components/bundle.css` and see the built-in component styling working correctly on the page.