### PR TITLE
add defaulting for deno

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -826,7 +826,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/answers-headless-react@1.1.0-beta.12
+ - @yext/answers-headless-react@1.1.0-alpha.7
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-react-components",
-  "version": "0.1.1-alpha.7",
+  "version": "0.1.1-alpha.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-react-components",
-      "version": "0.1.1-alpha.7",
+      "version": "0.1.1-alpha.8",
       "dependencies": {
         "@css-modules-theme/core": "^2.3.0",
         "@microsoft/api-documenter": "^7.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-react-components",
-  "version": "0.1.1-alpha.7",
+  "version": "0.1.1-alpha.8",
   "description": "",
   "author": "slapshot@yext.com",
   "main": "./lib/index.js",

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,16 +2,16 @@ import { createElement, isValidElement, PropsWithChildren, ReactNode, useMemo, u
 import { DropdownContext, DropdownContextType } from './DropdownContext';
 import { InputContext, InputContextType } from './InputContext';
 import useGlobalListener from '@restart/hooks/useGlobalListener';
-const useGlobalListenerHack = typeof document !== 'undefined' ? useGlobalListener : (useGlobalListener as any).default
+const useGlobalListenerHack = typeof document !== 'undefined' ? useGlobalListener : (useGlobalListener as any).default ?? useGlobalListener
 import useRootClose from '@restart/ui/useRootClose';
-const useRootCloseHack = typeof document !== 'undefined' ? useRootClose : (useRootClose as any).default;
+const useRootCloseHack = typeof document !== 'undefined' ? useRootClose : (useRootClose as any).default ?? useRootClose;
 import { FocusContext, FocusContextType } from './FocusContext';
 import { v4 as uuid } from 'uuid';
 import { ScreenReader } from '../ScreenReader';
 import { recursivelyMapChildren } from '../utils/recursivelyMapChildren';
 import { DropdownItem, DropdownItemProps, DropdownItemWithIndex } from './DropdownItem';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
-const useLayoutEffectHack = typeof document !== 'undefined' ? useLayoutEffect : (useLayoutEffect as any).default
+const useLayoutEffectHack = typeof document !== 'undefined' ? useLayoutEffect : (useLayoutEffect as any).default ?? useLayoutEffect
 
 interface DropdownItemData {
   value: string,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,16 +2,16 @@ import { createElement, isValidElement, PropsWithChildren, ReactNode, useMemo, u
 import { DropdownContext, DropdownContextType } from './DropdownContext';
 import { InputContext, InputContextType } from './InputContext';
 import useGlobalListener from '@restart/hooks/useGlobalListener';
-const useGlobalListenerHack = typeof document !== 'undefined' ? useGlobalListener : (useGlobalListener as any).default ?? useGlobalListener
+const useGlobalListenerHack = (useGlobalListener as any).default ?? useGlobalListener
 import useRootClose from '@restart/ui/useRootClose';
-const useRootCloseHack = typeof document !== 'undefined' ? useRootClose : (useRootClose as any).default ?? useRootClose;
+const useRootCloseHack = (useRootClose as any).default ?? useRootClose;
 import { FocusContext, FocusContextType } from './FocusContext';
 import { v4 as uuid } from 'uuid';
 import { ScreenReader } from '../ScreenReader';
 import { recursivelyMapChildren } from '../utils/recursivelyMapChildren';
 import { DropdownItem, DropdownItemProps, DropdownItemWithIndex } from './DropdownItem';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
-const useLayoutEffectHack = typeof document !== 'undefined' ? useLayoutEffect : (useLayoutEffect as any).default ?? useLayoutEffect
+const useLayoutEffectHack = (useLayoutEffect as any).default ?? useLayoutEffect
 
 interface DropdownItemData {
   value: string,

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import RecentSearches, { ISearch } from 'recent-searches';
-const RecentSearchesHack = (RecentSearches as any).default;
+const RecentSearchesHack = (RecentSearches as any).default ?? RecentSearches;
 
 export const RECENT_SEARCHES_KEY = '__yxt_recent_searches__';
 


### PR DESCRIPTION
Adds defaulting for `<pkg>.default` imports, since `<pkg>.default` does not exist in deno or on the browser, but is still necessary for node