### PR TITLE
specify cjs tailwind config in css build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "THIRD-PARTY-NOTICES"
   ],
   "scripts": {
-    "build": "rm -rf lib/** && tsc && tailwindcss -o ./lib/bundle.css --minify && npm run api-extractor && npm run generate-docs",
+    "build": "rm -rf lib/** && tsc && npm run build:css && npm run api-extractor && npm run generate-docs",
+    "build:css": "tailwindcss -o ./lib/bundle.css --minify -c tailwind.config.cjs",
     "dev": "tsc --watch",
     "lint": "eslint .",
     "api-extractor": "api-extractor run --local --verbose",


### PR DESCRIPTION
Tailwind does not automatically pick up on tailwind.config.cjs as a config file,
unlike tailwind.config.js .

In the future we probably want some automated way to test this.

J=NONE
TEST=manual

in the test-site, remove the tailwind config and comment out index.css contents
using the bundle.css shows correct styling
before the change, would not have correct styling
(for testing purposes, turned off type: module for both the component lib and answers-headless-react
due to type: module not working with create-react-app)

unminified, after running a css formatter, bundle.css was a little under 300 lines long
now, unminified, bundle.css is 1300 lines long