### PR TITLE
add commonjs support

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -32,7 +32,7 @@
    * SUPPORTED TOKENS: <lookup>
    * DEFAULT VALUE: "<lookup>"
    */
-  // "projectFolder": "..",
+  "projectFolder": ".",
 
   /**
    * (REQUIRED) Specifies the .d.ts file to be used as the starting point for analysis.  API Extractor
@@ -45,7 +45,7 @@
    *
    * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
    */
-  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/commonjs/index.d.ts",
 
   /**
    * A list of NPM package names whose exports should be treated as part of this package.
@@ -77,7 +77,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
      */
-    // "tsconfigFilePath": "<projectFolder>/tsconfig.json",
+    "tsconfigFilePath": "<projectFolder>/tsconfig.cjs.json"
     /**
      * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
      * The object must conform to the TypeScript tsconfig schema:

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -45,7 +45,7 @@
    *
    * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
    */
-  "mainEntryPointFilePath": "<projectFolder>/lib/commonjs/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/esm/index.d.ts",
 
   /**
    * A list of NPM package names whose exports should be treated as part of this package.
@@ -77,7 +77,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
      */
-    "tsconfigFilePath": "<projectFolder>/tsconfig.cjs.json"
+    "tsconfigFilePath": "<projectFolder>/tsconfig.esm.json"
     /**
      * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
      * The object must conform to the TypeScript tsconfig schema:

--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
   "version": "0.1.1-beta.7",
   "description": "",
   "author": "slapshot@yext.com",
-  "main": "./lib/commonjs/index.js",
-  "module": "./lib/esm/index.js",
-  "types": "./lib/answers-react-components.d.ts",
+  "main": "./lib/esm/index.js",
+  "types": "./lib/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/commonjs/index.js"
+    },
+    "./bundle.css": "./lib/bundle.css"
+  },
   "files": [
     "lib",
     "src",
@@ -16,7 +22,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:css": "tailwindcss -o ./lib/bundle.css --minify -c tailwind.config.cjs",
-    "dev": "tsc --watch",
+    "dev": "tsc --watch -p tsconfig.esm.json",
     "lint": "eslint .",
     "api-extractor": "api-extractor run --local --verbose",
     "generate-docs": "api-documenter markdown --input-folder temp --output-folder docs && rm -rf temp",
@@ -129,9 +135,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/yext/answers-react-components.git"
-  },
-  "exports": {
-    ".": "./lib/index.js",
-    "./bundle.css": "./lib/bundle.css"
   }
 }

--- a/package.json
+++ b/package.json
@@ -106,11 +106,6 @@
     "transformIgnorePatterns": [
       "/node_modules/(?!(@yext/answers-headless-react)/)"
     ],
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.json"
-      }
-    },
     "moduleNameMapper": {
       "./AnswersCore": "<rootDir>/tests/__fixtures__/core/AnswersCore.ts"
     },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   ],
   "scripts": {
     "build": "rm -rf lib/** && npm run build:cjs && npm run build:esm && npm run build:css && npm run api-extractor && npm run generate-docs",
-    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:css": "tailwindcss -o ./lib/bundle.css --minify -c tailwind.config.cjs",
     "dev": "tsc --watch -p tsconfig.esm.json",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -3,16 +3,18 @@
   "version": "0.1.1-beta.7",
   "description": "",
   "author": "slapshot@yext.com",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
-  "type": "module",
+  "main": "./lib/commonjs/index.js",
+  "module": "./lib/esm/index.js",
+  "types": "./lib/answers-react-components.d.ts",
   "files": [
     "lib",
     "src",
     "THIRD-PARTY-NOTICES"
   ],
   "scripts": {
-    "build": "rm -rf lib/** && tsc && npm run build:css && npm run api-extractor && npm run generate-docs",
+    "build": "rm -rf lib/** && npm run build:cjs && npm run build:esm && npm run build:css && npm run api-extractor && npm run generate-docs",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
     "build:css": "tailwindcss -o ./lib/bundle.css --minify -c tailwind.config.cjs",
     "dev": "tsc --watch",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "THIRD-PARTY-NOTICES"
   ],
   "scripts": {
-    "build": "rm -rf lib/** && npm run build:cjs && npm run build:esm && npm run build:css && npm run api-extractor && npm run generate-docs",
+    "build": "rm -rf lib/** && npm run build:esm && npm run build:cjs && npm run build:css && npm run api-extractor && npm run generate-docs",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:css": "tailwindcss -o ./lib/bundle.css --minify -c tailwind.config.cjs",

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -27,7 +27,7 @@
     },
     "..": {
       "name": "@yext/answers-react-components",
-      "version": "0.1.1-beta.6",
+      "version": "0.1.1-beta.7",
       "dependencies": {
         "@css-modules-theme/core": "^2.3.0",
         "@microsoft/api-documenter": "^7.15.3",
@@ -37,8 +37,10 @@
         "@tailwindcss/forms": "^0.5.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "classnames": "^2.3.1",
+        "prop-types": "^15.8.1",
         "react-collapsed": "^3.3.0",
         "recent-searches": "^1.0.5",
+        "use-isomorphic-layout-effect": "^1.1.2",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -65,7 +67,7 @@
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
-        "@yext/answers-headless-react": "^1.1.0-beta.11",
+        "@yext/answers-headless-react": "^1.1.0-beta.12",
         "@yext/eslint-config-slapshot": "^0.2.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -82,7 +84,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/answers-headless-react": "^1.1.0-beta.11",
+        "@yext/answers-headless-react": "^1.1.0-beta.12",
         "react": "^17.0.2"
       }
     },
@@ -14464,8 +14466,7 @@
       "dev": true
     },
     "../node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "../node_modules/use-latest": {
       "version": "1.2.0",
@@ -35365,7 +35366,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
-        "@yext/answers-headless-react": "^1.1.0-beta.11",
+        "@yext/answers-headless-react": "^1.1.0-beta.12",
         "@yext/eslint-config-slapshot": "^0.2.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -35377,12 +35378,14 @@
         "jest": "^27.5.1",
         "lodash": "^4.17.21",
         "msw": "^0.36.8",
+        "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-collapsed": "^3.3.0",
         "react-dom": "^17.0.2",
         "recent-searches": "^1.0.5",
         "tailwindcss": "^3.0.23",
         "typescript": "~4.4.3",
+        "use-isomorphic-layout-effect": "^1.1.2",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -50196,8 +50199,7 @@
           "dev": true
         },
         "use-isomorphic-layout-effect": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         },
         "use-latest": {
           "version": "1.2.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,10 +9,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "jsx": "react-jsx",
-    "target": "es2017",
-    "module": "es6",
-    "outDir": "lib"
+    "jsx": "react-jsx"
   },
   "include": [
     "src"

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "outDir": "lib/commonjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es6",
+    "outDir": "lib/esm",
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "es2017",
-    "module": "es6",
+    "module": "esnext",
     "outDir": "lib/esm",
   }
 }


### PR DESCRIPTION
This PR adds commonjs support by separating the tsconfig into esm and commonjs versions,
updating our api extractor config, and using conditional exports to provide the right entry point.

J=SLAP-2074
TEST=manual

test that the dev command works - I can hook up a local answers-react-components to a local 
project, and changes in answers-react-components will automatically be reflected in my project

test that answers-react-components works with yext sites SSR in both prod and dev mode
