### PR TITLE
remove wcag2aaa in storybook test

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,7 +13,7 @@ export const parameters = {
     options: {
       runOnly: {
         type: 'tag',
-        values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag2aaa'],
+        values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
       }
     }
   }


### PR DESCRIPTION
Product confirmed only wcag standards up to level AA is required. Remove wcag2aaa check for storybook.

J=SLAP-2056 & SLAP-2059
TEST=manual

see the color contrast violation from level AAA no longer appear in storybook's Spellcheck and AppliedFilters stories.