### PR TITLE
Fix DirectAnswer WCAG issues

### DIFF
--- a/src/components/ThumbsFeedback.tsx
+++ b/src/components/ThumbsFeedback.tsx
@@ -38,7 +38,7 @@ export interface ThumbsFeedbackProps {
 }
 
 export const builtInCssClasses: ThumbsFeedbackCssClasses = {
-  feedbackButtonsContainer: 'flex justify-end mt-2 text-sm text-gray-400 font-medium',
+  feedbackButtonsContainer: 'flex justify-end mt-2 text-sm text-gray-500 font-medium',
   thumbsUpIcon: 'ml-3 w-5',
   thumbsDownIcon: 'w-5 ml-1 transform rotate-180'
 };
@@ -85,12 +85,14 @@ export function ThumbsFeedback(props: ThumbsFeedbackProps): JSX.Element {
           <button
             className={cssClasses.thumbsUpIcon}
             onClick={handleClickThumbsUp}
+            aria-label='This answered my question'
           >
             <ThumbIcon/>
           </button>
           <button
             className={cssClasses.thumbsDownIcon}
             onClick={handleClickThumbsDown}
+            aria-label='This did not answer my question'
           >
             <ThumbIcon/>
           </button>

--- a/src/components/cards/standard/StandardCardDisplay.tsx
+++ b/src/components/cards/standard/StandardCardDisplay.tsx
@@ -36,7 +36,7 @@ const defaultStyling: StandardCardCssClasses = {
   cta1: 'whitespace-nowrap bg-primary text-white font-medium rounded-lg py-2 px-5 shadow',
   cta2: 'whitespace-nowrap bg-white text-primary font-medium rounded-lg py-2 px-5 mt-2 shadow',
   title: 'text-lg font-medium',
-  feedbackButtonsContainer: 'flex justify-end mt-4 text-sm text-gray-400 font-medium',
+  feedbackButtonsContainer: 'flex justify-end mt-4 text-sm text-gray-500 font-medium',
   thumbsUpIcon: thumbsFeedbackCssClasses.thumbsUpIcon,
   thumbsDownIcon: thumbsFeedbackCssClasses.thumbsDownIcon
 };


### PR DESCRIPTION
This PR fixes the WCAG issues from displaying thumbs feedback in `DirectAnswer` and `StandardCard` components.

The only remaining WCAG issues in Storybook are those from when a component is loading and at half opacity. Because components in this state are inactive, WCAG color contrast requirements don't apply (see Guideline 1.4.3 in [WCAG 2.0](https://www.w3.org/TR/2008/REC-WCAG20-20081211/)).

J=SLAP-2057
TEST=manual

Check that the WCAG issues for insufficient color contrast and missing button labels no longer appear in Storybook for the Field Value and Featured Snippet stories for `DirectAnswer`. See that now only Loading stories have WCAG issues and only for insufficient color contrast.