### PR TITLE
Add stories for ResultsCount component

### DIFF
--- a/tests/components/ResultsCount.stories.tsx
+++ b/tests/components/ResultsCount.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { AnswersHeadlessContext } from '@yext/answers-headless-react';
+
+import { ResultsCount } from '../../src/components/ResultsCount';
+
+import { generateMockedHeadless } from '../__fixtures__/answers-headless';
+import { VerticalSearcherState } from '../__fixtures__/headless-state';
+
+const meta: ComponentMeta<typeof ResultsCount> = {
+  title: 'ResultsCount',
+  component: ResultsCount,
+};
+export default meta;
+
+export const Primary = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...VerticalSearcherState,
+      vertical: {
+        resultsCount: 5
+      }
+    })}>
+      <ResultsCount />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const Loading = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...VerticalSearcherState,
+      vertical: {
+        resultsCount: 5
+      },
+      searchStatus: {
+        isLoading: true
+      }
+    })}>
+      <ResultsCount />
+    </AnswersHeadlessContext.Provider>
+  );
+};


### PR DESCRIPTION
Add 2 stories for ResultsCount component:
- Primary - results count display for vertical page
- Loading - result is in loading state

J=SLAP-2093
TEST=manual
<img width="250" alt="Screen Shot 2022-05-10 at 2 45 35 PM" src="https://user-images.githubusercontent.com/36055303/167700456-dfeecf54-42fa-4e8d-8580-e6640712a795.png">
<img width="250" alt="Screen Shot 2022-05-10 at 2 45 39 PM" src="https://user-images.githubusercontent.com/36055303/167700462-07f47b0b-4515-4583-b0f1-44b6dda7f697.png">

