### PR TITLE
add stories for AlternativeVerticals

### DIFF
--- a/tests/__fixtures__/data/verticalnoresults.ts
+++ b/tests/__fixtures__/data/verticalnoresults.ts
@@ -1,0 +1,59 @@
+import { AllResultsForVertical, Source, VerticalResults, VerticalSearchState } from '@yext/answers-headless-react';
+
+export const alternativeVerticals: VerticalResults[] = [
+  {
+    verticalKey: 'events',
+    source: Source.KnowledgeManager,
+    resultsCount: 2,
+    results: [{
+      description: 'How to make coffee',
+      name: 'Coffee Workshop',
+      rawData: {},
+      source: Source.KnowledgeManager,
+    }, {
+      description: 'How to taste coffee like a pro',
+      name: 'Coffee Tasting',
+      rawData: {},
+      source: Source.KnowledgeManager,
+    }],
+    queryDurationMillis: 30,
+    appliedQueryFilters: []
+  },
+  {
+    verticalKey: 'faqs',
+    source: Source.KnowledgeManager,
+    resultsCount: 1,
+    results: [{
+      description: 'Lots and lots of cleaning.',
+      name: 'What extra precautions are you taking for covid-19?',
+      rawData: {},
+      source: Source.KnowledgeManager,
+    }],
+    queryDurationMillis: 30,
+    appliedQueryFilters: []
+  }
+];
+
+export const allResultsForVertical: AllResultsForVertical = {
+  facets: [],
+  results: [{
+    name: 'Software Engineer',
+    rawData: {},
+    source: Source.KnowledgeManager,
+    description: 'Create software for computers and applications'
+  },
+  {
+    name: 'Product Manager',
+    rawData: {},
+    source: Source.KnowledgeManager,
+    description: 'Identifies the customer need and product\'s objectives'
+  }],
+  resultsCount: 2
+};
+
+export const verticalNoResults: VerticalSearchState = {
+  noResults: {
+    alternativeVerticals,
+    allResultsForVertical
+  }
+};

--- a/tests/components/AlternativeVerticals.stories.tsx
+++ b/tests/components/AlternativeVerticals.stories.tsx
@@ -74,16 +74,18 @@ const mockedHeadlessState = {
   }
 };
 
+const verticalConfigMap = {
+  faqs: { label: 'FAQs' },
+  events: { label: 'Events' },
+  locations: { label: 'Locations' }
+};
+
 export const Primary = () => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
       <AlternativeVerticals
         currentVerticalLabel='Jobs'
-        verticalConfigMap={{
-          faqs: { label: 'FAQs' },
-          events: { label: 'Events' },
-          locations: { label: 'Locations' }
-        }}
+        verticalConfigMap={verticalConfigMap}
         displayAllOnNoResults={false}
       />
     </AnswersHeadlessContext.Provider>
@@ -95,11 +97,7 @@ export const DisplayAllOnNoResults = () => {
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
       <AlternativeVerticals
         currentVerticalLabel='Jobs'
-        verticalConfigMap={{
-          faqs: { label: 'FAQs' },
-          events: { label: 'Events' },
-          locations: { label: 'Locations' }
-        }}
+        verticalConfigMap={verticalConfigMap}
         displayAllOnNoResults={true}
       />
     </AnswersHeadlessContext.Provider>
@@ -117,11 +115,7 @@ export const Loading = () => {
     })}>
       <AlternativeVerticals
         currentVerticalLabel='Jobs'
-        verticalConfigMap={{
-          faqs: { label: 'FAQs' },
-          events: { label: 'Events' },
-          locations: { label: 'Locations' }
-        }}
+        verticalConfigMap={verticalConfigMap}
         displayAllOnNoResults={true}
       />
     </AnswersHeadlessContext.Provider>

--- a/tests/components/AlternativeVerticals.stories.tsx
+++ b/tests/components/AlternativeVerticals.stories.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { ComponentMeta } from '@storybook/react';
-import { AllResultsForVertical, AnswersHeadlessContext, Source, VerticalResults } from '@yext/answers-headless-react';
+import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
 import { AlternativeVerticals } from '../../src/components/AlternativeVerticals';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
 import { VerticalSearcherState } from '../__fixtures__/headless-state';
+import { verticalNoResults } from '../__fixtures__/data/verticalnoresults';
 
 const meta: ComponentMeta<typeof AlternativeVerticals> = {
   title: 'AlternativeVerticals',
@@ -13,65 +14,9 @@ const meta: ComponentMeta<typeof AlternativeVerticals> = {
 };
 export default meta;
 
-const alternativeVerticals: VerticalResults[] = [
-  {
-    verticalKey: 'events',
-    source: Source.KnowledgeManager,
-    resultsCount: 2,
-    results: [{
-      description: 'How to make coffee',
-      name: 'Coffee Workshop',
-      rawData: {},
-      source: Source.KnowledgeManager,
-    }, {
-      description: 'How to taste coffee like a pro',
-      name: 'Coffee Tasting',
-      rawData: {},
-      source: Source.KnowledgeManager,
-    }],
-    queryDurationMillis: 30,
-    appliedQueryFilters: []
-  },
-  {
-    verticalKey: 'faqs',
-    source: Source.KnowledgeManager,
-    resultsCount: 1,
-    results: [{
-      description: 'Lots and lots of cleaning.',
-      name: 'What extra precautions are you taking for covid-19?',
-      rawData: {},
-      source: Source.KnowledgeManager,
-    }],
-    queryDurationMillis: 30,
-    appliedQueryFilters: []
-  }
-];
-
-const allResultsForVertical: AllResultsForVertical = {
-  facets: [],
-  results: [{
-    name: 'Software Engineer',
-    rawData: {},
-    source: Source.KnowledgeManager,
-    description: 'Create software for computers and applications'
-  },
-  {
-    name: 'Product Manager',
-    rawData: {},
-    source: Source.KnowledgeManager,
-    description: 'Identifies the customer need and product\'s objectives'
-  }],
-  resultsCount: 2
-};
-
 const mockedHeadlessState = {
   ...VerticalSearcherState,
-  vertical: {
-    noResults: {
-      alternativeVerticals,
-      allResultsForVertical
-    }
-  }
+  vertical: verticalNoResults
 };
 
 const verticalConfigMap = {

--- a/tests/components/AlternativeVerticals.stories.tsx
+++ b/tests/components/AlternativeVerticals.stories.tsx
@@ -90,7 +90,7 @@ export const Primary = () => {
   );
 };
 
-export const displayAllOnNoResults = () => {
+export const DisplayAllOnNoResults = () => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
       <AlternativeVerticals

--- a/tests/components/AlternativeVerticals.stories.tsx
+++ b/tests/components/AlternativeVerticals.stories.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { AllResultsForVertical, AnswersHeadlessContext, Source, VerticalResults } from '@yext/answers-headless-react';
+
+import { AlternativeVerticals } from '../../src/components/AlternativeVerticals';
+
+import { generateMockedHeadless } from '../__fixtures__/answers-headless';
+import { VerticalSearcherState } from '../__fixtures__/headless-state';
+
+const meta: ComponentMeta<typeof AlternativeVerticals> = {
+  title: 'AlternativeVerticals',
+  component: AlternativeVerticals,
+};
+export default meta;
+
+const alternativeVerticals: VerticalResults[] = [
+  {
+    verticalKey: 'events',
+    source: Source.KnowledgeManager,
+    resultsCount: 2,
+    results: [{
+      description: 'How to make coffee',
+      name: 'Coffee Workshop',
+      rawData: {},
+      source: Source.KnowledgeManager,
+    }, {
+      description: 'How to taste coffee like a pro',
+      name: 'Coffee Tasting',
+      rawData: {},
+      source: Source.KnowledgeManager,
+    }],
+    queryDurationMillis: 30,
+    appliedQueryFilters: []
+  },
+  {
+    verticalKey: 'faqs',
+    source: Source.KnowledgeManager,
+    resultsCount: 1,
+    results: [{
+      description: 'Lots and lots of cleaning.',
+      name: 'What extra precautions are you taking for covid-19?',
+      rawData: {},
+      source: Source.KnowledgeManager,
+    }],
+    queryDurationMillis: 30,
+    appliedQueryFilters: []
+  }
+];
+
+const allResultsForVertical: AllResultsForVertical = {
+  facets: [],
+  results: [{
+    name: 'Software Engineer',
+    rawData: {},
+    source: Source.KnowledgeManager,
+    description: 'Create software for computers and applications'
+  },
+  {
+    name: 'Product Manager',
+    rawData: {},
+    source: Source.KnowledgeManager,
+    description: 'Identifies the customer need and product\'s objectives'
+  }],
+  resultsCount: 2
+};
+
+const mockedHeadlessState = {
+  ...VerticalSearcherState,
+  vertical: {
+    noResults: {
+      alternativeVerticals,
+      allResultsForVertical
+    }
+  }
+};
+
+export const Primary = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
+      <AlternativeVerticals
+        currentVerticalLabel='Jobs'
+        verticalConfigMap={{
+          faqs: { label: 'FAQs' },
+          events: { label: 'Events' },
+          locations: { label: 'Locations' }
+        }}
+        displayAllOnNoResults={false}
+      />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const displayAllOnNoResults = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
+      <AlternativeVerticals
+        currentVerticalLabel='Jobs'
+        verticalConfigMap={{
+          faqs: { label: 'FAQs' },
+          events: { label: 'Events' },
+          locations: { label: 'Locations' }
+        }}
+        displayAllOnNoResults={true}
+      />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+
+export const Loading = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...mockedHeadlessState,
+      searchStatus: {
+        isLoading: true
+      }
+    })}>
+      <AlternativeVerticals
+        currentVerticalLabel='Jobs'
+        verticalConfigMap={{
+          faqs: { label: 'FAQs' },
+          events: { label: 'Events' },
+          locations: { label: 'Locations' }
+        }}
+        displayAllOnNoResults={true}
+      />
+    </AnswersHeadlessContext.Provider>
+  );
+};


### PR DESCRIPTION
Add storybook stories for AlternativeVerticals component:
- Primary: standard configuration for AlternativeVerticals, with displayAllOnNoResults as false
- DisplayAllOnNoResults: standard configuration for AlternativeVerticals, with displayAllOnNoResults as true
- Loading: search is in loading state

J=SLAP-2090
TEST=manual
<img width="600" alt="Screen Shot 2022-05-10 at 4 43 50 PM" src="https://user-images.githubusercontent.com/36055303/167718495-59802f66-a0a0-4c9d-b9c2-9460e2e36fb6.png">