### PR TITLE
Add stories for Pagination component

### DIFF
--- a/tests/components/Pagination.stories.tsx
+++ b/tests/components/Pagination.stories.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { AnswersHeadlessContext } from '@yext/answers-headless-react';
+
+import { Pagination } from '../../src/components/Pagination';
+
+import { generateMockedHeadless } from '../__fixtures__/answers-headless';
+import { VerticalSearcherState } from '../__fixtures__/headless-state';
+
+const meta: ComponentMeta<typeof Pagination> = {
+  title: 'Pagination',
+  component: Pagination,
+};
+export default meta;
+
+export const Primary = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...VerticalSearcherState,
+      vertical: {
+        resultsCount: 7,
+        limit: 1
+      }
+    })}>
+      <Pagination />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const PaginateAllOnNoResults = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...VerticalSearcherState,
+      vertical: {
+        resultsCount: 0,
+        noResults: {
+          allResultsForVertical: {
+            resultsCount: 550
+          }
+        }
+      }
+    })}>
+      <Pagination paginateAllOnNoResults={true} />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const OnMidPageWithEllipses = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...VerticalSearcherState,
+      vertical: {
+        resultsCount: 10,
+        limit: 1,
+        offset: 4
+      }
+    })}>
+      <Pagination />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const OnMidPage = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...VerticalSearcherState,
+      vertical: {
+        resultsCount: 7,
+        limit: 1,
+        offset: 3
+      }
+    })}>
+      <Pagination />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const OnLastPage = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...VerticalSearcherState,
+      vertical: {
+        resultsCount: 7,
+        limit: 1,
+        offset: 6
+      }
+    })}>
+      <Pagination />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const Loading = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless({
+      ...VerticalSearcherState,
+      vertical: {
+        resultsCount: 7,
+        limit: 1
+      },
+      searchStatus: {
+        isLoading: true
+      }
+    })}>
+      <Pagination />
+    </AnswersHeadlessContext.Provider>
+  );
+};


### PR DESCRIPTION
Add 6 stories for Pagination component:
- Primary: pagination UI for a results count of a search
- PaginateAllOnNoResults: pagination UI using total results count of a vertical when there's no results from a search
- OnMidPageWithEllipses:  UI when user is on the middle page number of the result set, with many more pages on each side of it which would collapse into ellipses.
- OnMidPage:  UI when user is on the middle page number of the result set, no ellipses.
- OnLastPage: UI when user is on the last page number of the result set
- Loading: when a search is in loading state


J=SLAP
TEST=auto

<img width="300" alt="Screen Shot 2022-05-11 at 3 39 55 PM" src="https://user-images.githubusercontent.com/36055303/167932401-fa637e0b-a87c-49c7-8d35-29bc56e4fef6.png"><img width="330" alt="Screen Shot 2022-05-11 at 3 40 07 PM" src="https://user-images.githubusercontent.com/36055303/167932422-043fa5f0-dde9-41b0-8885-44724cf5de1a.png"><img width="300" alt="Screen Shot 2022-05-11 at 3 40 15 PM" src="https://user-images.githubusercontent.com/36055303/167932428-383cd2d0-18ed-48ce-9fa6-48606e219e5d.png">


see that percy build captured all the new snapshots