### PR TITLE
Add stories for FilterSearch

### DIFF
--- a/tests/__fixtures__/data/filtersearch.ts
+++ b/tests/__fixtures__/data/filtersearch.ts
@@ -1,13 +1,17 @@
 export const unsectionedFilterSearchResponse = {
   sections: [
     {
-      results: [{
-        value: 'first name 1'
-      }, {
-        value: 'first name 2'
-      }, {
-        value: 'last name 1'
-      }],
+      results: [
+        {
+          value: 'first name 1'
+        },
+        {
+          value: 'first name 2'
+        },
+        {
+          value: 'last name 1'
+        }
+      ],
     }
   ],
   uuid: ''
@@ -16,16 +20,22 @@ export const unsectionedFilterSearchResponse = {
 export const sectionedFilterSearchResponse = {
   sections: [
     {
-      results: [{
-        value: 'first name 1'
-      }, {
-        value: 'first name 2'
-      }],
+      results: [
+        {
+          value: 'first name 1'
+        },
+        {
+          value: 'first name 2'
+        }
+      ],
       label: 'First name'
-    }, {
-      results: [{
-        value: 'last name 1'
-      }],
+    },
+    {
+      results: [
+        {
+          value: 'last name 1'
+        }
+      ],
       label: 'Last name'
     }
   ],

--- a/tests/__fixtures__/data/filtersearch.ts
+++ b/tests/__fixtures__/data/filtersearch.ts
@@ -1,0 +1,33 @@
+export const unsectionedFilterSearchResponse = {
+  sections: [
+    {
+      results: [{
+        value: 'first name 1'
+      }, {
+        value: 'first name 2'
+      }, {
+        value: 'last name 1'
+      }],
+    }
+  ],
+  uuid: ''
+};
+
+export const sectionedFilterSearchResponse = {
+  sections: [
+    {
+      results: [{
+        value: 'first name 1'
+      }, {
+        value: 'first name 2'
+      }],
+      label: 'First name'
+    }, {
+      results: [{
+        value: 'last name 1'
+      }],
+      label: 'Last name'
+    }
+  ],
+  uuid: ''
+};

--- a/tests/components/FilterSearch.stories.tsx
+++ b/tests/components/FilterSearch.stories.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { AnswersHeadlessContext, SearchTypeEnum } from '@yext/answers-headless-react';
+
+import { generateMockedHeadless } from '../__fixtures__/answers-headless';
+import { FilterSearch } from '../../src/components';
+import { userEvent, within } from '@storybook/testing-library';
+import { generateMockedAutocompleteService } from '../__fixtures__/core/autocomplete-service';
+import { sectionedFilterSearchResponse, unsectionedFilterSearchResponse } from '../__fixtures__/data/filtersearch';
+
+const mockedHeadlessState = {
+  vertical: {
+    verticalKey: 'people'
+  },
+  meta: {
+    searchType: SearchTypeEnum.Vertical
+  }
+};
+
+const searchFields = [
+  {
+    fieldApiName: 'first_name',
+    entityType: 'ce_person'
+  }, {
+    fieldApiName: 'last_name',
+    entityType: 'ce_person'
+  }
+];
+
+const meta: ComponentMeta<typeof FilterSearch> = {
+  title: 'FilterSearch',
+  component: FilterSearch,
+};
+export default meta;
+
+export const Primary = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
+      <FilterSearch searchFields={searchFields} />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const DropdownUnsectioned = Primary.bind({});
+DropdownUnsectioned.parameters = {
+  answersCoreServices: {
+    autoCompleteService: generateMockedAutocompleteService(undefined, unsectionedFilterSearchResponse)
+  }
+};
+DropdownUnsectioned.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  userEvent.type(canvas.getByRole('textbox'), 'name');
+};
+
+export const DropdownSectioned = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
+      <FilterSearch searchFields={searchFields} sectioned={true} />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+DropdownSectioned.parameters = {
+  answersCoreServices: {
+    autoCompleteService: generateMockedAutocompleteService(undefined, sectionedFilterSearchResponse)
+  }
+};
+DropdownSectioned.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  userEvent.type(canvas.getByRole('textbox'), 'name');
+};

--- a/tests/components/FilterSearch.stories.tsx
+++ b/tests/components/FilterSearch.stories.tsx
@@ -21,7 +21,8 @@ const searchFields = [
   {
     fieldApiName: 'first_name',
     entityType: 'ce_person'
-  }, {
+  },
+  {
     fieldApiName: 'last_name',
     entityType: 'ce_person'
   }


### PR DESCRIPTION
This PR adds 3 stories for the `FilterSearch` component.
- Primary: text input with dropdown closed
- DropdownUnsectioned: dropdown expanded with default, unsectioned results
- DropdownSectioned: dropdown expanded with sectioned results

J=SLAP-2091
TEST=auto

<img width="374" alt="Screen Shot 2022-05-11 at 5 01 14 PM" src="https://user-images.githubusercontent.com/88398086/167946941-39ac496e-7d19-41d1-bc20-cfdf080edd3a.png"> <img width="374" alt="Screen Shot 2022-05-11 at 5 01 37 PM" src="https://user-images.githubusercontent.com/88398086/167946997-8e2ab807-6dbb-4250-b58a-f87deccac0d6.png">
<img width="374" alt="Screen Shot 2022-05-11 at 5 01 59 PM" src="https://user-images.githubusercontent.com/88398086/167947043-7e2096ea-842b-43fa-8968-a71720e52a8a.png">