### PR TITLE
Add Storybook controls

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,6 +8,7 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+    expanded: true
   },
   a11y: {
     options: {

--- a/src/components/UniversalResults.tsx
+++ b/src/components/UniversalResults.tsx
@@ -22,11 +22,7 @@ export interface UniversalResultsCssClasses extends SectionHeaderCssClasses {
 const builtInCssClasses: UniversalResultsCssClasses = {
   container: 'space-y-8',
   results___loading: 'opacity-50',
-  sectionHeaderContainer: sectionHeaderCssClasses.sectionHeaderContainer,
-  sectionHeaderIconContainer: sectionHeaderCssClasses.sectionHeaderIconContainer,
-  sectionHeaderLabel: sectionHeaderCssClasses.sectionHeaderLabel,
-  viewMoreContainer: sectionHeaderCssClasses.viewMoreContainer,
-  viewMoreLink: sectionHeaderCssClasses.viewMoreLink
+  ...sectionHeaderCssClasses
 };
 
 /**

--- a/tests/__compound-components__/Filters/Facets.tsx
+++ b/tests/__compound-components__/Filters/Facets.tsx
@@ -1,8 +1,9 @@
 import { Filters } from '../../../src/components';
 
-export function Facets({ searchOnChange = true }: { searchOnChange?: boolean }): JSX.Element {
+export function Facets(args: Filters.FacetsProps): JSX.Element {
+  const searchOnChange = args.searchOnChange === false ? false : true;
   return (
-    <Filters.Facets searchOnChange={searchOnChange}>
+    <Filters.Facets {...args}>
       {facets => {
         const filteredFacets = facets.filter(f => f.options.length > 0);
         return (

--- a/tests/__compound-components__/Filters/Facets.tsx
+++ b/tests/__compound-components__/Filters/Facets.tsx
@@ -1,9 +1,12 @@
 import { Filters } from '../../../src/components';
 
 export function Facets(args: Filters.FacetsProps): JSX.Element {
-  const searchOnChange = args.searchOnChange === false ? false : true;
+  const config = {
+    searchOnChange: true,
+    ...args
+  };
   return (
-    <Filters.Facets {...args}>
+    <Filters.Facets {...config}>
       {facets => {
         const filteredFacets = facets.filter(f => f.options.length > 0);
         return (
@@ -22,7 +25,7 @@ export function Facets(args: Filters.FacetsProps): JSX.Element {
                       />
                     )}
                   </Filters.CollapsibleSection>
-                  {filteredFacets.length > 0 && !searchOnChange && <Filters.ApplyFiltersButton />}
+                  {filteredFacets.length > 0 && !config.searchOnChange && <Filters.ApplyFiltersButton />}
                 </Filters.FilterGroup>
               );
             })}

--- a/tests/__compound-components__/Filters/HierarchicalFacet.tsx
+++ b/tests/__compound-components__/Filters/HierarchicalFacet.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Filters } from '../../../src/components';
 
-export function HierarchicalFacets(): JSX.Element {
+export function HierarchicalFacets(args: Filters.HierarchicalFacetProps): JSX.Element {
   const hierarchicalFacetFieldIds = ['hier'];
   return (
     <Filters.Facets searchOnChange={true}>
@@ -13,7 +13,7 @@ export function HierarchicalFacets(): JSX.Element {
               filteredFacets.map(f => {
                 if (hierarchicalFacetFieldIds.includes(f.fieldId)) {
                   return <Fragment key={f.fieldId}>
-                    <Filters.HierarchicalFacet facet={f} />
+                    <Filters.HierarchicalFacet facet={f} {...args} />
                   </Fragment>;
                 }
                 return null;

--- a/tests/components/AlternativeVerticals.stories.tsx
+++ b/tests/components/AlternativeVerticals.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
-import { AlternativeVerticals } from '../../src/components/AlternativeVerticals';
+import { AlternativeVerticals, AlternativeVerticalsProps } from '../../src/components/AlternativeVerticals';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
 import { VerticalSearcherState } from '../__fixtures__/headless-state';
@@ -25,32 +25,34 @@ const verticalConfigMap = {
   locations: { label: 'Locations' }
 };
 
-export const Primary = () => {
+export const Primary = (args: AlternativeVerticalsProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
       <AlternativeVerticals
         currentVerticalLabel='Jobs'
         verticalConfigMap={verticalConfigMap}
         displayAllOnNoResults={false}
+        {...args}
       />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const DisplayAllOnNoResults = () => {
+export const DisplayAllOnNoResults = (args: AlternativeVerticalsProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
       <AlternativeVerticals
         currentVerticalLabel='Jobs'
         verticalConfigMap={verticalConfigMap}
         displayAllOnNoResults={true}
+        {...args}
       />
     </AnswersHeadlessContext.Provider>
   );
 };
 
 
-export const Loading = () => {
+export const Loading = (args: AlternativeVerticalsProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...mockedHeadlessState,
@@ -62,6 +64,7 @@ export const Loading = () => {
         currentVerticalLabel='Jobs'
         verticalConfigMap={verticalConfigMap}
         displayAllOnNoResults={true}
+        {...args}
       />
     </AnswersHeadlessContext.Provider>
   );

--- a/tests/components/AppliedFilters.stories.tsx
+++ b/tests/components/AppliedFilters.stories.tsx
@@ -10,6 +10,11 @@ import { AppliedFiltersProps, builtInCssClasses } from '../../src/components/App
 const meta: ComponentMeta<typeof AppliedFiltersDisplay> = {
   title: 'AppliedFilters',
   component: AppliedFiltersDisplay,
+  argTypes: {
+    hierarchicalFacetsDelimiter: {
+      control: false
+    }
+  }
 };
 export default meta;
 

--- a/tests/components/AppliedFilters.stories.tsx
+++ b/tests/components/AppliedFilters.stories.tsx
@@ -5,7 +5,7 @@ import { AnswersHeadlessContext, SearchTypeEnum } from '@yext/answers-headless-r
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
 import { AppliedFiltersDisplay } from '../../src/components/AppliedFiltersDisplay';
 import { DisplayableFilters, DisplayableHierarchicalFacets } from '../__fixtures__/data/filters';
-import { builtInCssClasses } from '../../src/components/AppliedFilters';
+import { AppliedFiltersProps, builtInCssClasses } from '../../src/components/AppliedFilters';
 
 const meta: ComponentMeta<typeof AppliedFiltersDisplay> = {
   title: 'AppliedFilters',
@@ -13,7 +13,7 @@ const meta: ComponentMeta<typeof AppliedFiltersDisplay> = {
 };
 export default meta;
 
-export const Primary = () => {
+export const Primary = (args: AppliedFiltersProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       meta: { searchType: SearchTypeEnum.Vertical }
@@ -25,6 +25,7 @@ export const Primary = () => {
         facets={[DisplayableFilters[3]]}
         hierarchicalFacets={DisplayableHierarchicalFacets}
         hierarchicalFacetsDelimiter='>'
+        {...args}
       />
     </AnswersHeadlessContext.Provider>
   );

--- a/tests/components/DirectAnswer.stories.tsx
+++ b/tests/components/DirectAnswer.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
-import { DirectAnswer } from '../../src/components/DirectAnswer';
+import { DirectAnswer, DirectAnswerProps } from '../../src/components/DirectAnswer';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
 import { featuredSnippetDAState, fieldValueDAState } from '../__fixtures__/data/directanswers';
@@ -13,33 +13,33 @@ const meta: ComponentMeta<typeof DirectAnswer> = {
 };
 export default meta;
 
-export const FieldValue = () => {
+export const FieldValue = (args: DirectAnswerProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       directAnswer: fieldValueDAState
     })}>
-      <DirectAnswer />
+      <DirectAnswer {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const FeaturedSnippet = () => {
+export const FeaturedSnippet = (args: DirectAnswerProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       directAnswer: featuredSnippetDAState
     })}>
-      <DirectAnswer />
+      <DirectAnswer {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const Loading = () => {
+export const Loading = (args: DirectAnswerProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       directAnswer: featuredSnippetDAState,
       searchStatus: { isLoading: true }
     })}>
-      <DirectAnswer />
+      <DirectAnswer {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/FilterSearch.stories.tsx
+++ b/tests/components/FilterSearch.stories.tsx
@@ -31,6 +31,14 @@ const searchFields = [
 const meta: ComponentMeta<typeof FilterSearch> = {
   title: 'FilterSearch',
   component: FilterSearch,
+  argTypes: {
+    sectioned: {
+      control: false
+    },
+    searchFields: {
+      control: false
+    }
+  }
 };
 export default meta;
 

--- a/tests/components/FilterSearch.stories.tsx
+++ b/tests/components/FilterSearch.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext, SearchTypeEnum } from '@yext/answers-headless-react';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
-import { FilterSearch } from '../../src/components';
+import { FilterSearch, FilterSearchProps } from '../../src/components';
 import { userEvent, within } from '@storybook/testing-library';
 import { generateMockedAutocompleteService } from '../__fixtures__/core/autocomplete-service';
 import { sectionedFilterSearchResponse, unsectionedFilterSearchResponse } from '../__fixtures__/data/filtersearch';
@@ -34,10 +34,10 @@ const meta: ComponentMeta<typeof FilterSearch> = {
 };
 export default meta;
 
-export const Primary = () => {
+export const Primary = (args: FilterSearchProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
-      <FilterSearch searchFields={searchFields} />
+      <FilterSearch searchFields={searchFields} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
@@ -53,10 +53,10 @@ DropdownUnsectioned.play = ({ canvasElement }) => {
   userEvent.type(canvas.getByRole('textbox'), 'name');
 };
 
-export const DropdownSectioned = () => {
+export const DropdownSectioned = (args: FilterSearchProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
-      <FilterSearch searchFields={searchFields} sectioned={true} />
+      <FilterSearch searchFields={searchFields} sectioned={true} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/Filters/Facets.stories.tsx
+++ b/tests/components/Filters/Facets.stories.tsx
@@ -21,10 +21,10 @@ const mockedHeadlessState: RecursivePartial<State> = {
   }
 };
 
-export const Primary = () => {
+export const Primary = (args: Filters.FacetsProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
-      <Facets />
+      <Facets {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/Filters/HierarchicalFacet.stories.tsx
+++ b/tests/components/Filters/HierarchicalFacet.stories.tsx
@@ -25,10 +25,10 @@ const mockedHeadlessState: RecursivePartial<State> = {
   }
 };
 
-export function Primary(): JSX.Element {
+export function Primary(args: Filters.HierarchicalFacetProps): JSX.Element {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
-      <HierarchicalFacets />
+      <HierarchicalFacets {...args} />
     </AnswersHeadlessContext.Provider>
   );
 }

--- a/tests/components/LocationBias.stories.tsx
+++ b/tests/components/LocationBias.stories.tsx
@@ -12,6 +12,11 @@ import { userEvent, within } from '@storybook/testing-library';
 const meta: ComponentMeta<typeof LocationBias> = {
   title: 'LocationBias',
   component: LocationBias,
+  argTypes: {
+    geolocationOptions: {
+      control: false
+    }
+  }
 };
 export default meta;
 

--- a/tests/components/LocationBias.stories.tsx
+++ b/tests/components/LocationBias.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext, LocationBiasMethod } from '@yext/answers-headless-react';
 
-import { LocationBias } from '../../src/components/LocationBias';
+import { LocationBias, LocationBiasProps } from '../../src/components/LocationBias';
 
 import { decorator as LocationOperationDecorator } from '../__fixtures__/utils/location-operations';
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
@@ -24,13 +24,13 @@ const mockedLocationData = {
   }
 };
 
-export const Primary = () => {
+export const Primary = (args: LocationBiasProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
       location: mockedLocationData
     })}>
-      <LocationBias />
+      <LocationBias {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/Pagination.stories.tsx
+++ b/tests/components/Pagination.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
-import { Pagination } from '../../src/components/Pagination';
+import { Pagination, PaginationProps } from '../../src/components/Pagination';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
 import { VerticalSearcherState } from '../__fixtures__/headless-state';
@@ -13,7 +13,7 @@ const meta: ComponentMeta<typeof Pagination> = {
 };
 export default meta;
 
-export const Primary = () => {
+export const Primary = (args: PaginationProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
@@ -22,12 +22,12 @@ export const Primary = () => {
         limit: 1
       }
     })}>
-      <Pagination />
+      <Pagination {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const PaginateAllOnNoResults = () => {
+export const PaginateAllOnNoResults = (args: PaginationProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
@@ -40,12 +40,12 @@ export const PaginateAllOnNoResults = () => {
         }
       }
     })}>
-      <Pagination paginateAllOnNoResults={true} />
+      <Pagination paginateAllOnNoResults={true} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const OnMidPageWithEllipses = () => {
+export const OnMidPageWithEllipses = (args: PaginationProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
@@ -55,12 +55,12 @@ export const OnMidPageWithEllipses = () => {
         offset: 4
       }
     })}>
-      <Pagination />
+      <Pagination {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const OnMidPage = () => {
+export const OnMidPage = (args: PaginationProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
@@ -70,12 +70,12 @@ export const OnMidPage = () => {
         offset: 3
       }
     })}>
-      <Pagination />
+      <Pagination {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const OnLastPage = () => {
+export const OnLastPage = (args: PaginationProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
@@ -85,12 +85,12 @@ export const OnLastPage = () => {
         offset: 6
       }
     })}>
-      <Pagination />
+      <Pagination {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const Loading = () => {
+export const Loading = (args: PaginationProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
@@ -102,7 +102,7 @@ export const Loading = () => {
         isLoading: true
       }
     })}>
-      <Pagination />
+      <Pagination {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/ResultsCount.stories.tsx
+++ b/tests/components/ResultsCount.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
-import { ResultsCount } from '../../src/components/ResultsCount';
+import { ResultsCount, ResultsCountProps } from '../../src/components/ResultsCount';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
 import { VerticalSearcherState } from '../__fixtures__/headless-state';
@@ -13,7 +13,7 @@ const meta: ComponentMeta<typeof ResultsCount> = {
 };
 export default meta;
 
-export const Primary = () => {
+export const Primary = (args: ResultsCountProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
@@ -21,12 +21,12 @@ export const Primary = () => {
         resultsCount: 5
       }
     })}>
-      <ResultsCount />
+      <ResultsCount {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const Loading = () => {
+export const Loading = (args: ResultsCountProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...VerticalSearcherState,
@@ -37,7 +37,7 @@ export const Loading = () => {
         isLoading: true
       }
     })}>
-      <ResultsCount />
+      <ResultsCount {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/SearchBar.stories.tsx
+++ b/tests/components/SearchBar.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
-import { SearchBar } from '../../src/components';
+import { SearchBar, SearchBarProps } from '../../src/components';
 import { userEvent, within } from '@storybook/testing-library';
 import { generateMockedAutocompleteService } from '../__fixtures__/core/autocomplete-service';
 
@@ -25,14 +25,19 @@ const meta: ComponentMeta<typeof SearchBar> = {
     answersCoreServices: {
       autoCompleteService: generateMockedAutocompleteService(mockedAutocompleteResult)
     }
+  },
+  argTypes: {
+    onSearch: {
+      control: false
+    }
   }
 };
 export default meta;
 
-export const Primary = () => {
+export const Primary = (args: SearchBarProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless()}>
-      <SearchBar />
+      <SearchBar {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/SearchBar.stories.tsx
+++ b/tests/components/SearchBar.stories.tsx
@@ -29,6 +29,9 @@ const meta: ComponentMeta<typeof SearchBar> = {
   argTypes: {
     onSearch: {
       control: false
+    },
+    geolocationOptions: {
+      control: false
     }
   }
 };

--- a/tests/components/SpellCheck.stories.tsx
+++ b/tests/components/SpellCheck.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext } from '@yext/answers-headless-react';
 
-import { SpellCheck } from '../../src/components/SpellCheck';
+import { SpellCheck, SpellCheckProps } from '../../src/components/SpellCheck';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
 import { VerticalSearcherState } from '../__fixtures__/headless-state';
@@ -13,10 +13,10 @@ const meta: ComponentMeta<typeof SpellCheck> = {
 };
 export default meta;
 
-export const Primary = () => {
+export const Primary = (args: SpellCheckProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(VerticalSearcherState)}>
-      <SpellCheck />
+      <SpellCheck {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/UniversalResults.stories.tsx
+++ b/tests/components/UniversalResults.stories.tsx
@@ -29,7 +29,7 @@ const verticalConfigMap = {
 export const Primary = (args: UniversalResultsProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
-      <UniversalResults verticalConfigMap={verticalConfigMap} {...args} />
+      <UniversalResults verticalConfigMap={verticalConfigMap} showAppliedFilters={true} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
@@ -40,7 +40,7 @@ export const Loading = (args: UniversalResultsProps) => {
       ...mockedHeadlessState,
       searchStatus: { isLoading: true }
     })}>
-      <UniversalResults verticalConfigMap={verticalConfigMap} {...args} />
+      <UniversalResults verticalConfigMap={verticalConfigMap} showAppliedFilters={true} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/UniversalResults.stories.tsx
+++ b/tests/components/UniversalResults.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta } from '@storybook/react';
 import { AnswersHeadlessContext, State } from '@yext/answers-headless-react';
 
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
-import { UniversalResults } from '../../src/components/UniversalResults';
+import { UniversalResults, UniversalResultsProps } from '../../src/components/UniversalResults';
 import { RecursivePartial } from '../__utils__/mocks';
 import { verticalResults } from '../__fixtures__/data/universalresults';
 
@@ -26,21 +26,21 @@ const verticalConfigMap = {
   }
 };
 
-export const Primary = () => {
+export const Primary = (args: UniversalResultsProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
-      <UniversalResults verticalConfigMap={verticalConfigMap} />
+      <UniversalResults verticalConfigMap={verticalConfigMap} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const Loading = () => {
+export const Loading = (args: UniversalResultsProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({
       ...mockedHeadlessState,
       searchStatus: { isLoading: true }
     })}>
-      <UniversalResults verticalConfigMap={verticalConfigMap} />
+      <UniversalResults verticalConfigMap={verticalConfigMap} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };

--- a/tests/components/VerticalResults.stories.tsx
+++ b/tests/components/VerticalResults.stories.tsx
@@ -9,6 +9,11 @@ import { StandardCard } from '../../src/components/cards/standard/StandardCard';
 const meta: ComponentMeta<typeof VerticalResults> = {
   title: 'VerticalResults',
   component: VerticalResults,
+  argTypes: {
+    CardComponent: {
+      control: false
+    }
+  }
 };
 export default meta;
 
@@ -39,42 +44,42 @@ const mockedHeadlessState = {
   }
 };
 
-export const NoResults = () => {
+export const NoResults = (args: VerticalResultsProps) => {
   const verticalResultsProps: VerticalResultsProps = {
     CardComponent: StandardCard
   };
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({})}>
-      <VerticalResults {...verticalResultsProps} />
+      <VerticalResults {...verticalResultsProps} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const HasResultsWithoutPagination = () => {
+export const HasResultsWithoutPagination = (args: VerticalResultsProps) => {
   const verticalResultsProps: VerticalResultsProps = {
     CardComponent: StandardCard,
     allowPagination: false
   };
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
-      <VerticalResults {...verticalResultsProps} />
+      <VerticalResults {...verticalResultsProps} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const HasResultsWithPagination = () => {
+export const HasResultsWithPagination = (args: VerticalResultsProps) => {
   const verticalResultsProps: VerticalResultsProps = {
     CardComponent: StandardCard,
     allowPagination: true
   };
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
-      <VerticalResults {...verticalResultsProps} />
+      <VerticalResults {...verticalResultsProps} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };
 
-export const Loading = () => {
+export const Loading = (args: VerticalResultsProps) => {
   const verticalResultsProps: VerticalResultsProps = {
     CardComponent: StandardCard
   };
@@ -83,7 +88,7 @@ export const Loading = () => {
       ...mockedHeadlessState,
       searchStatus: { isLoading: true }
     })}>
-      <VerticalResults {...verticalResultsProps} />
+      <VerticalResults {...verticalResultsProps} {...args} />
     </AnswersHeadlessContext.Provider>
   );
 };


### PR DESCRIPTION
This PR adds Storybook controls for each component's stories. This allows almost all component props to be configured from the Storybook UI. Props that are functions or objects containing functions (e.g. `onSearch`, `onClick`, `renderEntityPreviews`, etc.) cannot be directly configured via the controls (see https://storybook.js.org/docs/react/essentials/controls#dealing-with-complex-values).

Additionally, there are a few props that can be set, but their values don't affect the components because we are hardcoding the returned response results. I disabled the controls for these, but if we want to update the response based on those props in the future, they can easily be added back:
- `hierarchicalFacetsDelimiter` in `AppliedFiltersDisplay`
- `sectioned` and `searchFields` in `FilterSearch`
- `geolocationOptions` in `LocationBias` and `SearchBar`

The `expanded: true` config option in `.storybook/preview.js` ensures that the prop descriptions remain visible in the table on the Storybook site even after controls are enabled.

Lastly, I noticed that the applied filters styling was not being applied for universal results, so the `builtInCssClasses` in `UniversalResults` was updated to fix that and the corresponding stories were updated to display the applied filters by default.

J=SLAP-2094
TEST=manual

Went through each component's stories and checked that each prop is configurable using the controls and changes the display as expected except for those exceptions listed above.