### PR TITLE
react 18 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-react-components",
-  "version": "0.1.1-beta.8",
+  "version": "0.1.2-alpha.161",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-react-components",
-      "version": "0.1.1-beta.8",
+      "version": "0.1.2-alpha.161",
       "dependencies": {
         "@css-modules-theme/core": "^2.3.0",
         "@microsoft/api-documenter": "^7.15.3",
@@ -46,7 +46,7 @@
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
-        "@yext/answers-headless-react": "^1.1.1",
+        "@yext/answers-headless-react": "1.1.1-alpha.123",
         "@yext/eslint-config-slapshot": "^0.2.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -64,8 +64,8 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/answers-headless-react": "^1.1.1",
-        "react": "^17.0.2"
+        "@yext/answers-headless-react": "1.1.1-alpha.123",
+        "react": "^17 || ^18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3555,9 +3555,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
-      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
+      "integrity": "sha512-CtPw5TkN1pHRigMFCOS/0qg3b/yfPV5qGCsltVnIz7bx4PKTJlGHYfIxm97qskLknMzuGfjExaYdXJ77QTL0vg==",
       "dev": true,
       "dependencies": {
         "immer": "^9.0.7",
@@ -7635,29 +7635,28 @@
       }
     },
     "node_modules/@yext/answers-headless": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0.tgz",
-      "integrity": "sha512-LLwf9ANcVDIvUmKqjLU2WWEC7fOS1y9EshWw1YGR1BeFkMuVRSpR7/UYQEreyfc5CqlT9MHewt7VF+CjqlXFjA==",
+      "version": "1.1.1-alpha.0-95",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.1-alpha.0-95.tgz",
+      "integrity": "sha512-HmIasoefl0aeKUGQhkgZjG1aCcjNvbcmjR/eYWJ1Uef4sJvpeImvbrzIFlabX6mnCzK9uS72AajNvd5d4evMyQ==",
       "dev": true,
       "dependencies": {
-        "@reduxjs/toolkit": "^1.7.0",
-        "@yext/answers-core": "^1.6.0",
+        "@reduxjs/toolkit": "^1.8.1",
+        "@yext/answers-core": "^1.6.0-beta.7",
         "js-levenshtein": "^1.1.6",
-        "lodash": "^4.17.21",
-        "redux-thunk": "^2.4.1"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@yext/answers-headless-react": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless-react/-/answers-headless-react-1.1.1.tgz",
-      "integrity": "sha512-iw2UcwZGILq49AZB0QXgPVHmzOG6Hb2VUJ0cDVBbY7y8OxOChQ/Ar3VcnYJxElzxekMaI6fcCS87eQsI6unSHQ==",
+      "version": "1.1.1-alpha.123",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless-react/-/answers-headless-react-1.1.1-alpha.123.tgz",
+      "integrity": "sha512-uXSRkGHAUza8+ZZZLBDqsIbtkyp0Lji9tkjt2+fxvNRuBouC0j4mDpj8wvgMki4El/NCbillMZk1EqHO9E3/qQ==",
       "dev": true,
       "dependencies": {
-        "@yext/answers-headless": "^1.1.0",
-        "use-isomorphic-layout-effect": "^1.1.2"
+        "@yext/answers-headless": "1.1.1-alpha.0-95",
+        "use-sync-external-store": "^1.1.0"
       },
       "peerDependencies": {
-        "react": "^17.0.2"
+        "react": "^17 || ^18"
       }
     },
     "node_modules/@yext/eslint-config-slapshot": {
@@ -14655,9 +14654,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.13.tgz",
-      "integrity": "sha512-LufFIoBO2q3CZoUiObiV6ICK7QsrxOIo8ReQHggmYHA7aSbQdsAiZ+mkR3cjRD5ZxC/0P6EMdx2kk6oj1qyFLw==",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.14.tgz",
+      "integrity": "sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -23715,6 +23714,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.11.1",
       "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
@@ -27513,9 +27521,9 @@
       }
     },
     "@reduxjs/toolkit": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
-      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
+      "integrity": "sha512-CtPw5TkN1pHRigMFCOS/0qg3b/yfPV5qGCsltVnIz7bx4PKTJlGHYfIxm97qskLknMzuGfjExaYdXJ77QTL0vg==",
       "dev": true,
       "requires": {
         "immer": "^9.0.7",
@@ -30499,26 +30507,25 @@
       }
     },
     "@yext/answers-headless": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0.tgz",
-      "integrity": "sha512-LLwf9ANcVDIvUmKqjLU2WWEC7fOS1y9EshWw1YGR1BeFkMuVRSpR7/UYQEreyfc5CqlT9MHewt7VF+CjqlXFjA==",
+      "version": "1.1.1-alpha.0-95",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.1-alpha.0-95.tgz",
+      "integrity": "sha512-HmIasoefl0aeKUGQhkgZjG1aCcjNvbcmjR/eYWJ1Uef4sJvpeImvbrzIFlabX6mnCzK9uS72AajNvd5d4evMyQ==",
       "dev": true,
       "requires": {
-        "@reduxjs/toolkit": "^1.7.0",
-        "@yext/answers-core": "^1.6.0",
+        "@reduxjs/toolkit": "^1.8.1",
+        "@yext/answers-core": "^1.6.0-beta.7",
         "js-levenshtein": "^1.1.6",
-        "lodash": "^4.17.21",
-        "redux-thunk": "^2.4.1"
+        "lodash": "^4.17.21"
       }
     },
     "@yext/answers-headless-react": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless-react/-/answers-headless-react-1.1.1.tgz",
-      "integrity": "sha512-iw2UcwZGILq49AZB0QXgPVHmzOG6Hb2VUJ0cDVBbY7y8OxOChQ/Ar3VcnYJxElzxekMaI6fcCS87eQsI6unSHQ==",
+      "version": "1.1.1-alpha.123",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless-react/-/answers-headless-react-1.1.1-alpha.123.tgz",
+      "integrity": "sha512-uXSRkGHAUza8+ZZZLBDqsIbtkyp0Lji9tkjt2+fxvNRuBouC0j4mDpj8wvgMki4El/NCbillMZk1EqHO9E3/qQ==",
       "dev": true,
       "requires": {
-        "@yext/answers-headless": "^1.1.0",
-        "use-isomorphic-layout-effect": "^1.1.2"
+        "@yext/answers-headless": "1.1.1-alpha.0-95",
+        "use-sync-external-store": "^1.1.0"
       }
     },
     "@yext/eslint-config-slapshot": {
@@ -35918,9 +35925,9 @@
       }
     },
     "immer": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.13.tgz",
-      "integrity": "sha512-LufFIoBO2q3CZoUiObiV6ICK7QsrxOIo8ReQHggmYHA7aSbQdsAiZ+mkR3cjRD5ZxC/0P6EMdx2kk6oj1qyFLw==",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.14.tgz",
+      "integrity": "sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw==",
       "dev": true
     },
     "import-fresh": {
@@ -42756,6 +42763,13 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "dev": true,
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-react-components",
-  "version": "0.1.1-beta.8",
+  "version": "0.1.2-alpha.161",
   "description": "",
   "author": "slapshot@yext.com",
   "main": "./lib/esm/index.js",
@@ -55,7 +55,7 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
-    "@yext/answers-headless-react": "^1.1.1",
+    "@yext/answers-headless-react": "1.1.1-alpha.123",
     "@yext/eslint-config-slapshot": "^0.2.0",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.3",
@@ -73,8 +73,8 @@
     "typescript": "~4.4.3"
   },
   "peerDependencies": {
-    "@yext/answers-headless-react": "^1.1.1",
-    "react": "^17.0.2"
+    "@yext/answers-headless-react": "1.1.1-alpha.123",
+    "react": "^17 || ^18"
   },
   "jest": {
     "bail": 0,

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -67,7 +67,7 @@
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
-        "@yext/answers-headless-react": "^1.1.1",
+        "@yext/answers-headless-react": "1.1.1-alpha.123",
         "@yext/eslint-config-slapshot": "^0.2.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -85,8 +85,8 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/answers-headless-react": "^1.1.1",
-        "react": "^17.0.2"
+        "@yext/answers-headless-react": "1.1.1-alpha.123",
+        "react": "^17 || ^18"
       }
     },
     "../node_modules/@ampproject/remapping": {
@@ -35367,7 +35367,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
-        "@yext/answers-headless-react": "^1.1.1",
+        "@yext/answers-headless-react": "1.1.1-alpha.123",
         "@yext/eslint-config-slapshot": "^0.2.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",


### PR DESCRIPTION
update `package.json` to use latest headless-react version with react 18 support and include v18 for react in peer dependencies. Will defer to another item to upgrade test environment to v18 since there were some `npm WARN ERESOLVE overriding peer dependency` logs for some dev deps, such as storybook packages, that haven't fully switch to v18 support yet.

J=SLAP-2095
TEST=manual

manually link component lib to test-site and have test-site use react v17/18. Smoke test on universal and vertical pages.