### PR TITLE
Update Storybook site sync workflow

### DIFF
--- a/.github/workflows/sync-sites-branch.yml
+++ b/.github/workflows/sync-sites-branch.yml
@@ -11,10 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: repo-sync/pull-request@v2
+      - uses: mtanzi/action-automerge@v1
         with:
-          source_branch: "${{ github.event.repository.default_branch }}"
-          destination_branch: "storybook-site"
-          pr_title: "Merge ${{ github.event.repository.default_branch }} into storybook-site"
-          pr_body: "Merge ${{ github.event.repository.default_branch }} into storybook-site"
+          source: "${{ github.event.repository.default_branch }}"
+          target: "storybook-site"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the `sync-site-branch` workflow to automatically merge `main` into the `storybook-site` branch whenever there is a push to `main`. This uses a new GitHub action: [mtanzi/action-automerge](https://github.com/mtanzi/action-automerge). Now, instead of making a PR that has to be manually merged in, the bot will make a merge commit automatically. If there is a merge conflict, the workflow will fail, in which case the conflict would need to be resolved manually and merged into the `storybook-site`.

J=SLAP-2119
TEST=manual

Fork the repo, update the workflow, and make commits to main. See that they are automatically merged into the storybook-site branch. Test that the workflow fails if the merge is not successful (e.g. merge conflict).