### PR TITLE
VisualAutocomplete: change universalLimit and restrictVerticals to simple props

### DIFF
--- a/src/components/EntityPreviews.tsx
+++ b/src/components/EntityPreviews.tsx
@@ -1,4 +1,4 @@
-import { Result, VerticalResults as VerticalResultsData, UniversalLimit } from '@yext/answers-headless-react';
+import { Result, VerticalResults as VerticalResultsData } from '@yext/answers-headless-react';
 import { cloneElement, isValidElement, ReactNode } from 'react';
 import { DropdownItem } from './Dropdown/DropdownItem';
 import { recursivelyMapChildren } from './utils/recursivelyMapChildren';
@@ -12,9 +12,7 @@ export interface EntityPreviewsProps {
   /** Results associated with the provided verticalKey are passed to the EntityPreviews children function. */
   verticalKey: string,
   /** The entity preview render function which is passed results for the specified vertical. */
-  children: (results: Result[], index: number) => JSX.Element,
-  /** Limits the number of results provided to the render function. */
-  limit?: number
+  children: (results: Result[], index: number) => JSX.Element
 }
 
 /**
@@ -69,39 +67,6 @@ function getVerticalKeyToResults(verticalResultsArray: VerticalResultsData[]): R
   return verticalResultsArray.reduce<Record<string, Result[]>>((prev, current) => {
     prev[current.verticalKey] = current.results;
     return prev;
-  }, {});
-}
-
-/**
- * Calculates the restrictVerticals query param from a ReactNode containing EntityPreviews.
- */
-export function calculateRestrictVerticals(children: ReactNode): string[] {
-  const restrictedVerticalsSet = new Set<string>();
-  recursivelyMapChildren(children, c => {
-    if (isValidElement(c) && c.type === EntityPreviews) {
-      const { verticalKey } = c.props as EntityPreviewsProps;
-      restrictedVerticalsSet.add(verticalKey);
-    }
-    return c;
-  });
-  return Array.from(restrictedVerticalsSet);
-}
-
-/**
- * Calculates the universalLimit query param from a ReactNode containing EntityPreviews.
- */
-export function calculateUniversalLimit(children: ReactNode): UniversalLimit {
-  const universalLimit: Record<string, number | null> = {};
-  recursivelyMapChildren(children, c => {
-    if (isValidElement(c) && c.type === EntityPreviews) {
-      const { verticalKey, limit } = c.props as EntityPreviewsProps;
-      universalLimit[verticalKey] = limit || null;
-    }
-    return c;
-  });
-  return Object.keys(universalLimit).reduce<UniversalLimit>((limitWithDefaults, verticalKey) => {
-    limitWithDefaults[verticalKey] = universalLimit[verticalKey] ?? 4;
-    return limitWithDefaults;
   }, {});
 }
 

--- a/test-site/src/App.tsx
+++ b/test-site/src/App.tsx
@@ -9,14 +9,7 @@ import {
   Routes,
 } from 'react-router-dom';
 import { AnalyticsProvider } from '@yext/answers-react-components';
-
-const config = {
-  apiKey: '2d8c550071a64ea23e263118a2b0680b',
-  experienceKey: 'slanswers-hier-facets',
-  locale: 'en',
-  experienceVersion: 'STAGING',
-  businessId: 123123
-}
+import { config } from './config';
 
 function App() {
   return (

--- a/test-site/src/config.ts
+++ b/test-site/src/config.ts
@@ -1,0 +1,7 @@
+export const config = {
+  apiKey: '2d8c550071a64ea23e263118a2b0680b',
+  experienceKey: 'slanswers-hier-facets',
+  locale: 'en',
+  experienceVersion: 'STAGING',
+  businessId: 123123
+}

--- a/test-site/src/pages/PeoplePage.tsx
+++ b/test-site/src/pages/PeoplePage.tsx
@@ -7,7 +7,7 @@ import {
   StandardCard,
   VerticalResults,
   LocationBias,
-  StaticFilters
+  StaticFilters,
 } from '@yext/answers-react-components';
 import { useLayoutEffect } from 'react';
 import { Facets, hierarchicalFacetFieldIds } from '../components/Facets';
@@ -20,7 +20,8 @@ export function PeoplePage() {
 
   return (
     <div>
-      <SearchBar />
+      <SearchBar 
+      />
       <div className='flex'>
         <div className='min-w-fit pr-4'>
           <Facets />

--- a/test-site/src/pages/UniversalPage.tsx
+++ b/test-site/src/pages/UniversalPage.tsx
@@ -1,12 +1,44 @@
-import { useAnswersActions } from '@yext/answers-headless-react';
+import { provideAnswersHeadless, useAnswersActions } from '@yext/answers-headless-react';
 import {
   DirectAnswer,
   ResultsCount,
   SearchBar,
   SpellCheck,
-  UniversalResults
+  UniversalResults,
+  EntityPreviews,
+  VisualAutocompleteConfig
 } from '@yext/answers-react-components';
 import { useLayoutEffect } from 'react';
+import { config } from '../config';
+
+
+const visualAutocompleteConfig: VisualAutocompleteConfig = {
+  entityPreviewSearcher: provideAnswersHeadless({
+    ...config,
+    headlessId: 'visual-autocomplete'
+  }),
+  restrictVerticals: ['people'],
+  renderEntityPreviews: isLoading => (
+    <div className={isLoading ? 'opacity-50' : ''}>
+      <EntityPreviews verticalKey='people'>
+        {results => (
+          <div className='flex ml-4 mt-1'>
+            {results.map((r, index) =>
+              <div
+                key={index + '-' + r.name}
+                tabIndex={0}
+                className='flex flex-col mb-3 mr-4 border rounded-md p-3 text-lg'
+              >
+                {r.name}
+              </div>
+            )}
+          </div>
+        )}
+      </EntityPreviews>
+    </div>
+  )
+}
+
 
 export default function UniversalPage(): JSX.Element {
   const answersActions = useAnswersActions();
@@ -16,7 +48,9 @@ export default function UniversalPage(): JSX.Element {
 
   return (
     <div>
-      <SearchBar />
+      <SearchBar 
+        visualAutocompleteConfig={visualAutocompleteConfig}
+      />
       <SpellCheck />
       <DirectAnswer />
       <ResultsCount />


### PR DESCRIPTION
This PR removes automatic detection of universalLimit and restrictVerticals based
on props passed into EntityPreviews.

J=SLAP-2118
TEST=manual

add VA to the test-site
see it display properly