### PR TITLE
Make `builtInCssClasses` readonly

### DIFF
--- a/docs/answers-react-components.usecomposedcssclasses.md
+++ b/docs/answers-react-components.usecomposedcssclasses.md
@@ -9,14 +9,14 @@ useComposedCssClasses merges a component's built-in tailwind classes with custom
 <b>Signature:</b>
 
 ```typescript
-export declare function useComposedCssClasses<ClassInterface extends Partial<Record<keyof ClassInterface & string, string>>>(builtInClasses: ClassInterface, customClasses?: Partial<ClassInterface>): ClassInterface;
+export declare function useComposedCssClasses<ClassInterface extends Partial<Record<keyof ClassInterface & string, string>>>(builtInClasses: Readonly<ClassInterface>, customClasses?: Partial<ClassInterface>): ClassInterface;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  builtInClasses | ClassInterface | The component's built-in tailwind classes |
+|  builtInClasses | Readonly&lt;ClassInterface&gt; | The component's built-in tailwind classes |
 |  customClasses | Partial&lt;ClassInterface&gt; | The custom tailwind classes to merge with the built-in ones |
 
 <b>Returns:</b>

--- a/etc/answers-react-components.api.md
+++ b/etc/answers-react-components.api.md
@@ -737,7 +737,7 @@ export function useCardAnalyticsCallback(result: Result | DirectAnswer_2, analyt
 export function useCardFeedbackCallback(result: Result | DirectAnswer_2): (analyticsType: FeedbackType) => void;
 
 // @public
-export function useComposedCssClasses<ClassInterface extends Partial<Record<keyof ClassInterface & string, string>>>(builtInClasses: ClassInterface, customClasses?: Partial<ClassInterface>): ClassInterface;
+export function useComposedCssClasses<ClassInterface extends Partial<Record<keyof ClassInterface & string, string>>>(builtInClasses: Readonly<ClassInterface>, customClasses?: Partial<ClassInterface>): ClassInterface;
 
 // @public
 export interface VerticalConfig {

--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -26,7 +26,7 @@ export interface AlternativeVerticalsCssClasses {
   allCategoriesLink?: string
 }
 
-const builtInCssClasses: AlternativeVerticalsCssClasses = {
+const builtInCssClasses: Readonly<AlternativeVerticalsCssClasses> = {
   container: 'flex flex-col justify-between border rounded-lg mb-4 p-4 shadow-sm',
   alternativeVerticals___loading: 'opacity-50',
   noResultsText: 'text-lg text-neutral-dark pb-2',

--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -23,7 +23,7 @@ export interface AppliedFiltersCssClasses {
   clearAllButton?: string
 }
 
-export const builtInCssClasses: AppliedFiltersCssClasses = {
+export const builtInCssClasses: Readonly<AppliedFiltersCssClasses> = {
   // Use negative margin to remove space above the filters on mobile
   appliedFiltersContainer: 'flex flex-wrap -mt-3 md:mt-0 mb-2',
   appliedFiltersContainer___loading: 'opacity-50',

--- a/src/components/ApplyFiltersButton.tsx
+++ b/src/components/ApplyFiltersButton.tsx
@@ -24,7 +24,7 @@ export interface ApplyFiltersButtonCssClasses {
   button?: string
 }
 
-const builtInCssClasses: ApplyFiltersButtonCssClasses = {
+const builtInCssClasses: Readonly<ApplyFiltersButtonCssClasses> = {
   button: 'border border-gray-300 px-2.5 py-1 rounded-md text-primary bg-white shadow-md sticky bottom-3'
 };
 

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -41,7 +41,7 @@ export interface DirectAnswerCssClasses extends ThumbsFeedbackCssClasses {
   answerContainer?: string
 }
 
-const builtInCssClasses: DirectAnswerCssClasses = {
+const builtInCssClasses: Readonly<DirectAnswerCssClasses> = {
   container: '',
   container___loading: 'opacity-50',
   fieldValueTitle: 'mb-4 text-neutral',

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -27,7 +27,7 @@ export interface FilterSearchCssClasses extends AutocompleteResultCssClasses {
   inputContainer?: string
 }
 
-const builtInCssClasses: FilterSearchCssClasses = {
+const builtInCssClasses: Readonly<FilterSearchCssClasses> = {
   container: 'mb-2',
   label: 'mb-4 text-sm font-medium text-neutral-dark',
   dropdownContainer: 'absolute z-10 shadow-lg rounded-md border border-gray-300 bg-white pt-3 pb-1 px-4 mt-1',

--- a/src/components/Filters/CheckboxOption.tsx
+++ b/src/components/Filters/CheckboxOption.tsx
@@ -49,7 +49,7 @@ export interface CheckboxCssClasses {
   tooltip?: string
 }
 
-const builtInCssClasses: CheckboxCssClasses = {
+const builtInCssClasses: Readonly<CheckboxCssClasses> = {
   label: 'text-neutral text-sm font-normal cursor-pointer',
   label___disabled: 'opacity-50 cursor-not-allowed',
   input: 'w-3.5 h-3.5 form-checkbox cursor-pointer border border-gray-300 rounded-sm text-primary focus:ring-primary',

--- a/src/components/Filters/HierarchicalFacetDisplay.tsx
+++ b/src/components/Filters/HierarchicalFacetDisplay.tsx
@@ -39,7 +39,7 @@ export interface HierarchicalFacetDisplayCssClasses {
   showMoreButton?: string
 }
 
-const builtInCssClasses: Required<HierarchicalFacetDisplayCssClasses> = {
+const builtInCssClasses: Readonly<HierarchicalFacetDisplayCssClasses> = {
   treeContainer: 'flex flex-col items-start',
   allCategoriesOption___active: 'font-semibold mb-2 text-sm',
   allCategoriesOption___inactive: 'mb-2 text-sm',

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -61,7 +61,7 @@ export interface RangeInputCssClasses {
   invalidRowContainer?: string
 }
 
-const builtInCssClasses: RangeInputCssClasses = {
+const builtInCssClasses: Readonly<RangeInputCssClasses> = {
   container: 'flex flex-col',
   input: 'w-24 h-9 form-input cursor-pointer border rounded-md focus:ring-0 text-neutral-dark text-sm appearance-none leading-9',
   input___withPrefix: 'pl-[1.375rem]',

--- a/src/components/LocationBias.tsx
+++ b/src/components/LocationBias.tsx
@@ -18,7 +18,7 @@ export interface LocationBiasCssClasses {
   loadingIndicatorContainer?: string
 }
 
-const builtInCssClasses: LocationBiasCssClasses = {
+const builtInCssClasses: Readonly<LocationBiasCssClasses> = {
   container: 'text-sm text-neutral text-center flex justify-center items-center',
   location: 'font-semibold mr-1',
   button: 'text-primary hover:underline focus:underline ml-1',

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -38,7 +38,7 @@ export interface PaginationCssClasses {
   icon?: string
 }
 
-const builtInPaginationCssClasses: PaginationCssClasses = {
+const builtInPaginationCssClasses: Readonly<PaginationCssClasses> = {
   paginationContainer: 'flex justify-center mb-4',
   paginationContainer___loading: 'opacity-50',
   labelContainer: 'inline-flex shadow-sm -space-x-px',

--- a/src/components/ResultsCount.tsx
+++ b/src/components/ResultsCount.tsx
@@ -28,7 +28,7 @@ export interface ResultsCountProps {
   customCssClasses?: ResultsCountCssClasses
 }
 
-const builtInCssClasses: ResultsCountCssClasses = {
+const builtInCssClasses: Readonly<ResultsCountCssClasses> = {
   resultCountText: 'font-semibold text-neutral mb-4 py-2 mr-2.5',
   resultCountText___loading: 'opacity-50'
 };

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -40,7 +40,7 @@ import { clearStaticRangeFilters } from '../utils/filterutils';
 import { useMemo } from 'react';
 import { recursivelyMapChildren } from './utils/recursivelyMapChildren';
 
-const builtInCssClasses: SearchBarCssClasses = {
+const builtInCssClasses: Readonly<SearchBarCssClasses> = {
   container: 'h-12 mb-6',
   inputDivider: 'border-t border-gray-200 mx-2.5',
   dropdownContainer: 'bg-white py-4 z-10',

--- a/src/components/SpellCheck.tsx
+++ b/src/components/SpellCheck.tsx
@@ -16,7 +16,7 @@ export interface SpellCheckCssClasses {
   link?: string
 }
 
-const builtInCssClasses: SpellCheckCssClasses = {
+const builtInCssClasses: Readonly<SpellCheckCssClasses> = {
   container: 'text-lg pb-3',
   helpText: 'text-neutral',
   spellCheck___loading: 'opacity-50',

--- a/src/components/ThumbsFeedback.tsx
+++ b/src/components/ThumbsFeedback.tsx
@@ -37,7 +37,7 @@ export interface ThumbsFeedbackProps {
   cssClasses: ThumbsFeedbackCssClasses
 }
 
-export const builtInCssClasses: ThumbsFeedbackCssClasses = {
+export const builtInCssClasses: Readonly<ThumbsFeedbackCssClasses> = {
   feedbackButtonsContainer: 'flex justify-end mt-2 text-sm text-gray-500 font-medium',
   thumbsUpIcon: 'ml-3 w-5',
   thumbsDownIcon: 'w-5 ml-1 transform rotate-180'

--- a/src/components/UniversalResults.tsx
+++ b/src/components/UniversalResults.tsx
@@ -19,7 +19,7 @@ export interface UniversalResultsCssClasses extends SectionHeaderCssClasses {
   results___loading?: string
 }
 
-const builtInCssClasses: UniversalResultsCssClasses = {
+const builtInCssClasses: Readonly<UniversalResultsCssClasses> = {
   container: 'space-y-8',
   results___loading: 'opacity-50',
   ...sectionHeaderCssClasses

--- a/src/components/VerticalResultsDisplay.tsx
+++ b/src/components/VerticalResultsDisplay.tsx
@@ -4,7 +4,7 @@ import { Result } from '@yext/answers-headless-react';
 import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import classNames from 'classnames';
 
-const builtInCssClasses: VerticalResultsCssClasses = {
+const builtInCssClasses: Readonly<VerticalResultsCssClasses> = {
   results___loading: 'opacity-50'
 };
 

--- a/src/components/cards/standard/StandardCardDisplay.tsx
+++ b/src/components/cards/standard/StandardCardDisplay.tsx
@@ -29,7 +29,7 @@ interface StandardCardCssClasses extends ThumbsFeedbackCssClasses {
 /**
  * Default Tailwind styles for the StandardCardDisplay.
  */
-const defaultStyling: StandardCardCssClasses = {
+const builtInCssClasses: Readonly<StandardCardCssClasses> = {
   container: 'flex flex-col justify-between border rounded-lg mb-4 p-4 shadow-sm',
   header: 'flex text-neutral-dark',
   body: 'flex justify-end pt-2.5 text-base',
@@ -83,7 +83,7 @@ function StandardCardDisplay(props: StandardCardDisplayProps) {
     cta1,
     cta2
   } = props;
-  const cssClasses = useComposedCssClasses(defaultStyling, customCssClasses);
+  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
 
   function renderTitle(title: string | HighlightedValue, link?: string) {
     const titleJsx = renderHighlightedValue(title, { highlighted: 'font-bold', nonHighlighted: 'font-medium' });

--- a/src/components/sections/SectionHeader.tsx
+++ b/src/components/sections/SectionHeader.tsx
@@ -22,7 +22,7 @@ export interface SectionHeaderCssClasses extends AppliedFiltersCssClasses {
   viewMoreLink?: string
 }
 
-export const builtInCssClasses: SectionHeaderCssClasses = {
+export const builtInCssClasses: Readonly<SectionHeaderCssClasses> = {
   sectionHeaderContainer: 'flex items-center w-full pl-1 mb-4',
   sectionHeaderIconContainer: 'w-5 h-5',
   sectionHeaderLabel: 'font-bold text-neutral-dark text-base pl-3',

--- a/src/components/sections/StandardSection.tsx
+++ b/src/components/sections/StandardSection.tsx
@@ -13,7 +13,7 @@ export interface StandardSectionCssClasses extends VerticalResultsCssClasses {
   section?: string
 }
 
-const builtInCssClasses: StandardSectionCssClasses = {
+const builtInCssClasses: Readonly<StandardSectionCssClasses> = {
   section: ''
 };
 

--- a/src/components/utils/renderAutocompleteResult.tsx
+++ b/src/components/utils/renderAutocompleteResult.tsx
@@ -13,7 +13,7 @@ export interface AutocompleteResultCssClasses {
   nonHighlighted?: string
 }
 
-export const builtInCssClasses = {
+export const builtInCssClasses: Readonly<AutocompleteResultCssClasses> = {
   option: 'flex whitespace-pre-wrap h-6.5 pl-3 text-neutral-dark',
   icon: 'w-6 text-gray-400'
 };

--- a/src/hooks/useComposedCssClasses.tsx
+++ b/src/hooks/useComposedCssClasses.tsx
@@ -49,7 +49,7 @@ const twMerge = extendTailwindMerge({
 export function useComposedCssClasses<
   ClassInterface extends Partial<Record<keyof ClassInterface & string, string>>
 >(
-  builtInClasses: ClassInterface,
+  builtInClasses: Readonly<ClassInterface>,
   customClasses?: Partial<ClassInterface>
 ): ClassInterface {
   return useMemo(() => {

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -39,7 +39,7 @@
         "prop-types": "^15.8.1",
         "react-collapsed": "^3.3.0",
         "recent-searches": "^1.0.5",
-        "tailwind-merge": "^1.2.1",
+        "tailwind-merge": "^1.3.0",
         "use-isomorphic-layout-effect": "^1.1.2",
         "uuid": "^8.3.2"
       },
@@ -35385,7 +35385,7 @@
         "react-collapsed": "^3.3.0",
         "react-dom": "^17.0.2",
         "recent-searches": "^1.0.5",
-        "tailwind-merge": "^1.2.1",
+        "tailwind-merge": "^1.3.0",
         "tailwindcss": "^3.0.23",
         "typescript": "~4.4.3",
         "use-isomorphic-layout-effect": "^1.1.2",


### PR DESCRIPTION
This PR makes each component's `builtInCssClasses` readonly.

I opted to use the Typescript `Readonly` utility type which adds `readonly` to each of the properties of an object. Although, this is a shallow operation, in the case of the `builtInCssClasses`, this is sufficient because the object will only contain properties with string values. I initially tried using const assertions, but because we define the type for the classes, such as `const builtInCssClasses: SearchBarCssClasses = { ... }`, it seems to override the const assertion and allows the properties to be modified.

J=SLAP-2136
TEST=manual

Tried modifying the classes in `builtInCssClasses` and saw it gives an error about not being able to assign to read-only properties.