### PR TITLE
add stories for RangeInput

### DIFF
--- a/tests/components/AlternativeVerticals.stories.tsx
+++ b/tests/components/AlternativeVerticals.stories.tsx
@@ -51,7 +51,6 @@ export const DisplayAllOnNoResults = (args: AlternativeVerticalsProps) => {
   );
 };
 
-
 export const Loading = (args: AlternativeVerticalsProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless({

--- a/tests/components/RangeInput.stories.tsx
+++ b/tests/components/RangeInput.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { RangeInput, RangeInputProps } from '../../src/components/Filters/RangeInput';
+import { AnswersHeadlessContext, State } from '@yext/answers-headless-react';
+import { generateMockedHeadless } from '../__fixtures__/answers-headless';
+import { RecursivePartial } from '../__utils__/mocks';
+import { FiltersContext, FiltersContextType } from '../../src/components/Filters/FiltersContext';
+import { FilterGroupContext, FilterGroupContextType } from '../../src/components/Filters/FilterGroupContext';
+
+
+const meta: ComponentMeta<typeof RangeInput> = {
+  title: 'RangeInput',
+  component: RangeInput,
+};
+
+export default meta;
+
+const mockedHeadlessState: RecursivePartial<State> = {};
+
+const filterContextValue: FiltersContextType = {
+  selectFilter: () => null,
+  applyFilters: () => null,
+  filters: []
+};
+
+const filterGroupContextValue: FilterGroupContextType = {
+  searchValue: '',
+  fieldId: '',
+  setSearchValue: () => null,
+  getCollapseProps: null,
+  getToggleProps: null,
+  isExpanded: null,
+  isOptionsDisabled: null,
+  setIsOptionsDisabled: () => null
+};
+
+export const Primary = (args: RangeInputProps) => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput {...args}/>
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>
+    </AnswersHeadlessContext.Provider>
+  );
+};

--- a/tests/components/RangeInput.stories.tsx
+++ b/tests/components/RangeInput.stories.tsx
@@ -65,11 +65,13 @@ export const Disabled = ((args: RangeInputProps) => {
       </FilterGroupContext.Provider>
     </AnswersHeadlessContext.Provider>
   );
+// eslint-disable-next-line no-extra-bind
 }).bind({});
 Disabled.play = ({ canvasElement }) => {
   const canvas = within(canvasElement);
   const [minTextbox] = canvas.getAllByRole('textbox');
-  userEvent.hover(minTextbox);
+  const minbox = minTextbox.parentElement.parentElement;
+  userEvent.hover(minbox);
 };
 
 export const validValues = Primary.bind({});

--- a/tests/components/RangeInput.stories.tsx
+++ b/tests/components/RangeInput.stories.tsx
@@ -55,7 +55,7 @@ export const Primary = (args: RangeInputProps) => {
   );
 };
 
-export const Disabled = ((args: RangeInputProps) => {
+export const Disabled = (args: RangeInputProps) => {
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless()}>
       <FilterGroupContext.Provider value={filterGroupContextValue}>
@@ -65,25 +65,25 @@ export const Disabled = ((args: RangeInputProps) => {
       </FilterGroupContext.Provider>
     </AnswersHeadlessContext.Provider>
   );
-// eslint-disable-next-line no-extra-bind
-}).bind({});
-Disabled.play = ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  const [minTextbox] = canvas.getAllByRole('textbox');
-  const minbox = minTextbox.parentElement.parentElement;
-  userEvent.hover(minbox);
 };
 
-export const validValues = Primary.bind({});
-validValues.play = ({ canvasElement }) => {
+export const DisabledForceDisplayTooltip = Disabled.bind({});
+DisabledForceDisplayTooltip.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const tooltip = canvas.getByText('Unselect an option to enter in a range.').parentElement;
+  tooltip.style.visibility = 'visible';
+};
+
+export const ValidValues = Primary.bind({});
+ValidValues.play = ({ canvasElement }) => {
   const canvas = within(canvasElement);
   const [minTextbox, maxTextbox] = canvas.getAllByRole('textbox');
   userEvent.type(minTextbox, '10');
   userEvent.type(maxTextbox, '20');
 };
 
-export const invalidValues = Primary.bind({});
-invalidValues.play = ({ canvasElement }) => {
+export const InvalidValues = Primary.bind({});
+InvalidValues.play = ({ canvasElement }) => {
   const canvas = within(canvasElement);
   const [minTextbox, maxTextbox] = canvas.getAllByRole('textbox');
   userEvent.type(minTextbox, '20');

--- a/tests/components/RangeInput.stories.tsx
+++ b/tests/components/RangeInput.stories.tsx
@@ -1,13 +1,10 @@
 import { ComponentMeta } from '@storybook/react';
 import { RangeInput, RangeInputProps } from '../../src/components/Filters/RangeInput';
-import { AnswersHeadlessContext, State } from '@yext/answers-headless-react';
+import { AnswersHeadlessContext, Matcher, SelectableFilter } from '@yext/answers-headless-react';
 import { generateMockedHeadless } from '../__fixtures__/answers-headless';
-import { RecursivePartial } from '../__utils__/mocks';
 import { FiltersContext, FiltersContextType } from '../../src/components/Filters/FiltersContext';
 import { FilterGroupContext, FilterGroupContextType } from '../../src/components/Filters/FilterGroupContext';
 import { userEvent, within } from '@storybook/testing-library';
-import { max } from 'lodash';
-
 
 const meta: ComponentMeta<typeof RangeInput> = {
   title: 'RangeInput',
@@ -16,7 +13,12 @@ const meta: ComponentMeta<typeof RangeInput> = {
 
 export default meta;
 
-const mockedHeadlessState: RecursivePartial<State> = {};
+const selectableFilter: SelectableFilter = {
+  selected: true,
+  fieldId: '123',
+  matcher: Matcher.Equals,
+  value: 'test'
+};
 
 const filterContextValue: FiltersContextType = {
   selectFilter: () => null,
@@ -24,9 +26,15 @@ const filterContextValue: FiltersContextType = {
   filters: []
 };
 
+const filterContextValueDisabled: FiltersContextType = {
+  selectFilter: () => null,
+  applyFilters: () => null,
+  filters: [selectableFilter]
+};
+
 const filterGroupContextValue: FilterGroupContextType = {
   searchValue: '',
-  fieldId: '',
+  fieldId: '123',
   setSearchValue: () => null,
   getCollapseProps: null,
   getToggleProps: null,
@@ -37,7 +45,7 @@ const filterGroupContextValue: FilterGroupContextType = {
 
 export const Primary = (args: RangeInputProps) => {
   return (
-    <AnswersHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless()}>
       <FilterGroupContext.Provider value={filterGroupContextValue}>
         <FiltersContext.Provider value={filterContextValue}>
           <RangeInput {...args}/>
@@ -45,6 +53,23 @@ export const Primary = (args: RangeInputProps) => {
       </FilterGroupContext.Provider>
     </AnswersHeadlessContext.Provider>
   );
+};
+
+export const Disabled = ((args: RangeInputProps) => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless()}>
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValueDisabled}>
+          <RangeInput {...args}/>
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>
+    </AnswersHeadlessContext.Provider>
+  );
+}).bind({});
+Disabled.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const [minTextbox] = canvas.getAllByRole('textbox');
+  userEvent.hover(minTextbox);
 };
 
 export const validValues = Primary.bind({});

--- a/tests/components/RangeInput.stories.tsx
+++ b/tests/components/RangeInput.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { RangeInput, RangeInputProps } from '../../src/components/Filters/RangeInput';
 import { AnswersHeadlessContext, State } from '@yext/answers-headless-react';
@@ -6,6 +5,8 @@ import { generateMockedHeadless } from '../__fixtures__/answers-headless';
 import { RecursivePartial } from '../__utils__/mocks';
 import { FiltersContext, FiltersContextType } from '../../src/components/Filters/FiltersContext';
 import { FilterGroupContext, FilterGroupContextType } from '../../src/components/Filters/FilterGroupContext';
+import { userEvent, within } from '@storybook/testing-library';
+import { max } from 'lodash';
 
 
 const meta: ComponentMeta<typeof RangeInput> = {
@@ -44,4 +45,20 @@ export const Primary = (args: RangeInputProps) => {
       </FilterGroupContext.Provider>
     </AnswersHeadlessContext.Provider>
   );
+};
+
+export const validValues = Primary.bind({});
+validValues.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const [minTextbox, maxTextbox] = canvas.getAllByRole('textbox');
+  userEvent.type(minTextbox, '10');
+  userEvent.type(maxTextbox, '20');
+};
+
+export const invalidValues = Primary.bind({});
+invalidValues.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const [minTextbox, maxTextbox] = canvas.getAllByRole('textbox');
+  userEvent.type(minTextbox, '20');
+  userEvent.type(maxTextbox, '10');
 };


### PR DESCRIPTION
This PR adds storybook stories for RangeInput, testing:
- basic range input
- disabled input
- valid range
- invalid range

J=SLAP-2146
TEST=manual

<img width="764" alt="Screen Shot 2022-06-15 at 4 20 52 PM" src="https://user-images.githubusercontent.com/59857107/173920146-5545b3ce-93c9-4306-9c3d-ad248fd634f2.png">
<img width="767" alt="Screen Shot 2022-06-15 at 4 21 08 PM" src="https://user-images.githubusercontent.com/59857107/173920207-9a81a077-a484-459a-9342-d37cd7fb142c.png">
<img width="764" alt="Screen Shot 2022-06-15 at 4 21 20 PM" src="https://user-images.githubusercontent.com/59857107/173920227-98c44de4-9efe-4252-9768-324033e2ad55.png">
<img width="766" alt="Screen Shot 2022-06-15 at 4 21 44 PM" src="https://user-images.githubusercontent.com/59857107/173920240-dd1306d1-4756-4eec-8041-34bc88b06f37.png">
<img width="764" alt="Screen Shot 2022-06-15 at 4 21 55 PM" src="https://user-images.githubusercontent.com/59857107/173920246-c09711f0-b112-4e60-bf34-7b21718f11b2.png">