### PR TITLE
Remove old filter values

### DIFF
--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -96,13 +96,13 @@ export function FilterSearch({
   }, [filterSearchResponse?.sections]);
 
   const hasResults = sections.flatMap(s => s.results).length > 0;
-  const [currentFilter, setCurrentFilter] = useState(null as unknown as Filter);
+  const [currentFilter, setCurrentFilter] = useState<Filter>();
 
   const handleSelectDropdown = useCallback((_value, _index, itemData) => {
     const newFilter = itemData?.filter as Filter;
     const newDisplayName = itemData?.displayName as string;
     if (newFilter && newDisplayName) {
-      if (!!currentFilter) {
+      if (currentFilter) {
         answersActions.setFilterOption({ ...currentFilter, selected: false });
       }
       answersActions.setFilterOption({ ...newFilter, displayName: newDisplayName, selected: true });

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -1,5 +1,5 @@
 import { AutocompleteResult, Filter, FilterSearchResponse, SearchParameterField, useAnswersActions } from '@yext/answers-headless-react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import { useSynchronizedRequest } from '../hooks/useSynchronizedRequest';
 import { executeSearch } from '../utils';
@@ -96,18 +96,23 @@ export function FilterSearch({
   }, [filterSearchResponse?.sections]);
 
   const hasResults = sections.flatMap(s => s.results).length > 0;
+  const [currentFilter, setCurrentFilter] = useState(null as unknown as Filter);
 
   const handleSelectDropdown = useCallback((_value, _index, itemData) => {
-    const filter = itemData?.filter as Filter;
-    const displayName = itemData?.displayName as string;
-    if (filter && displayName) {
-      answersActions.setFilterOption({ ...filter, displayName, selected: true });
+    const newFilter = itemData?.filter as Filter;
+    const newDisplayName = itemData?.displayName as string;
+    if (newFilter && newDisplayName) {
+      if (!!currentFilter) {
+        answersActions.setFilterOption({ ...currentFilter, selected: false });
+      }
+      answersActions.setFilterOption({ ...newFilter, displayName: newDisplayName, selected: true });
+      setCurrentFilter(newFilter);
       answersActions.setOffset(0);
       if (searchOnSelect) {
         executeSearch(answersActions);
       }
     }
-  }, [answersActions, searchOnSelect]);
+  }, [answersActions, currentFilter, searchOnSelect]);
 
   const meetsSubmitCritera = useCallback(index => index >= 0, []);
 

--- a/tests/__fixtures__/data/filtersearch.ts
+++ b/tests/__fixtures__/data/filtersearch.ts
@@ -54,6 +54,6 @@ export const noResultsFilterSearchResponse: FilterSearchResponse = {
   sections: [{
     results:[]
   }],
-  uuid: null
+  uuid: ''
 };
 

--- a/tests/components/FilterSearch.test.tsx
+++ b/tests/components/FilterSearch.test.tsx
@@ -117,7 +117,6 @@ describe('search with section labels', () => {
 
     userEvent.type(searchBarElement, 'n');
     await waitFor(() => screen.findByText('first name 1'));
-
     userEvent.type(searchBarElement, '{arrowdown}{enter}');
     expect(setFilterOption).toBeCalledWith({
       fieldId: 'name',

--- a/tests/components/FilterSearch.test.tsx
+++ b/tests/components/FilterSearch.test.tsx
@@ -111,6 +111,41 @@ describe('search with section labels', () => {
     expect(searchBarElement).toHaveValue('first name 2');
   });
 
+  it('remove old filter value when a new one is entered', async () => {
+    render(<FilterSearch searchFields={searchFieldsProp} />);
+    const searchBarElement = screen.getByRole('textbox');
+
+    userEvent.type(searchBarElement, 'n');
+    await waitFor(() => screen.findByText('first name 1'));
+
+    userEvent.type(searchBarElement, '{arrowdown}{enter}');
+    expect(setFilterOption).toBeCalledWith({
+      fieldId: 'name',
+      matcher: Matcher.Equals,
+      value: 'first name 1',
+      displayName: 'first name 1',
+      selected: true
+    });
+
+    userEvent.clear(searchBarElement);
+    userEvent.type(searchBarElement, 'n');
+    await waitFor(() => screen.findByText('first name 2'));
+    userEvent.type(searchBarElement, '{arrowdown}{arrowdown}{enter}');
+    expect(setFilterOption).toBeCalledWith({
+      fieldId: 'name',
+      matcher: Matcher.Equals,
+      value: 'first name 1',
+      selected: false
+    });
+    expect(setFilterOption).toBeCalledWith({
+      fieldId: 'name',
+      matcher: Matcher.Equals,
+      value: 'first name 2',
+      displayName: 'first name 2',
+      selected: true
+    });
+  });
+
   describe('searchOnSelect = true', () => {
     it('triggers a search on pressing "enter" when an autocomplete result is selected', async () => {
       const mockExecuteSearch = jest.spyOn(searchOperations, 'executeSearch').mockImplementation();
@@ -209,8 +244,6 @@ describe('search with section labels', () => {
 describe('search without section labels', () => {
   it('shows autocomplete results, if they exist, when a character is typed', async () => {
     mockAnswersActions({
-      setFilterOption,
-      setOffset,
       executeFilterSearch: jest.fn().mockResolvedValue(unlabeledFilterSearchResponse)
     });
     jest.spyOn(searchOperations, 'executeSearch').mockImplementation();
@@ -229,8 +262,6 @@ describe('search without section labels', () => {
 describe('screen reader', () => {
   it('renders ScreenReader messages with section labels', async () => {
     mockAnswersActions({
-      setFilterOption,
-      setOffset,
       executeFilterSearch: jest.fn().mockResolvedValue(labeledFilterSearchResponse)
     });
 
@@ -247,8 +278,6 @@ describe('screen reader', () => {
 
   it('renders ScreenReader messages without section labels', async () => {
     mockAnswersActions({
-      setFilterOption,
-      setOffset,
       executeFilterSearch: jest.fn().mockResolvedValue(unlabeledFilterSearchResponse)
     });
 
@@ -265,8 +294,6 @@ describe('screen reader', () => {
 
   it('renders 0 results ScreenReader message when there are no results', async () => {
     mockAnswersActions({
-      setFilterOption,
-      setOffset,
       executeFilterSearch: jest.fn().mockResolvedValue(noResultsFilterSearchResponse)
     });
 

--- a/tests/components/FilterSearch.test.tsx
+++ b/tests/components/FilterSearch.test.tsx
@@ -78,12 +78,14 @@ describe('search with section labels', () => {
     expect(actions.executeFilterSearch).toHaveBeenCalledTimes(3);
   });
 
-  it('does not trigger a filter search when backspacing in an empty text box', () => {
+  it('does not trigger a filter search when backspacing in an empty text box', async () => {
     render(<FilterSearch searchFields={searchFieldsProp} />);
     const searchBarElement = screen.getByRole('textbox');
 
     userEvent.type(searchBarElement, '{backspace}');
-    expect(searchBarElement).toHaveValue('');
+    await waitFor(() => {
+      expect(searchBarElement).toHaveValue('');
+    });
     expect(actions.executeFilterSearch).toHaveBeenCalledTimes(0);
   });
 
@@ -118,23 +120,27 @@ describe('search with section labels', () => {
     userEvent.type(searchBarElement, 'n');
     await waitFor(() => screen.findByText('first name 1'));
     userEvent.type(searchBarElement, '{arrowdown}{enter}');
-    expect(setFilterOption).toBeCalledWith({
-      fieldId: 'name',
-      matcher: Matcher.Equals,
-      value: 'first name 1',
-      displayName: 'first name 1',
-      selected: true
+    await waitFor (() => {
+      expect(setFilterOption).toBeCalledWith({
+        fieldId: 'name',
+        matcher: Matcher.Equals,
+        value: 'first name 1',
+        displayName: 'first name 1',
+        selected: true
+      });
     });
 
     userEvent.clear(searchBarElement);
     userEvent.type(searchBarElement, 'n');
     await waitFor(() => screen.findByText('first name 2'));
     userEvent.type(searchBarElement, '{arrowdown}{arrowdown}{enter}');
-    expect(setFilterOption).toBeCalledWith({
-      fieldId: 'name',
-      matcher: Matcher.Equals,
-      value: 'first name 1',
-      selected: false
+    await waitFor(() => {
+      expect(setFilterOption).toBeCalledWith({
+        fieldId: 'name',
+        matcher: Matcher.Equals,
+        value: 'first name 1',
+        selected: false
+      });
     });
     expect(setFilterOption).toBeCalledWith({
       fieldId: 'name',
@@ -164,7 +170,9 @@ describe('search with section labels', () => {
       const expectedSetOffsetParam = 0;
 
       userEvent.type(searchBarElement, '{arrowdown}{enter}');
-      expect(setFilterOption).toBeCalledWith(expectedSetFilterOptionParam);
+      await waitFor(() => {
+        expect(setFilterOption).toBeCalledWith(expectedSetFilterOptionParam);
+      });
       expect(setOffset).toBeCalledWith(expectedSetOffsetParam);
 
       const setFilterOptionCallOrder = setFilterOption.mock.invocationCallOrder[0];
@@ -227,12 +235,14 @@ describe('search with section labels', () => {
       await waitFor(() => screen.findByText('first name 1'));
 
       userEvent.type(searchBarElement, '{arrowdown}{enter}');
-      expect(setFilterOption).toBeCalledWith({
-        fieldId: 'name',
-        matcher: Matcher.Equals,
-        value: 'first name 1',
-        displayName: 'first name 1',
-        selected: true
+      await waitFor(() => {
+        expect(setFilterOption).toBeCalledWith({
+          fieldId: 'name',
+          matcher: Matcher.Equals,
+          value: 'first name 1',
+          displayName: 'first name 1',
+          selected: true
+        });
       });
       expect(setOffset).toBeCalledWith(0);
       expect(mockExecuteSearch).not.toHaveBeenCalled();


### PR DESCRIPTION
This PR changes FIlterSearch such that you can only have one filter at a time.  When you add the first filter, it is set as a filter option for the next search.  Upon further addition of searched filters, the old ones will be replaced by the newly searched ones.  Note that backspacing from the filter box does not remove the filter (just as ZocDoc does for its doctor filter).

J=SLAP-2142
TEST=auto

One jest test was added to test the added functionality.