### PR TITLE
Jest tests for RangeInput component

### DIFF
--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -122,7 +122,9 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   const hasUserInput = !!(minRangeInput || maxRangeInput);
   const shouldRenderApplyButton = hasUserInput && !isSelectedInAnswersState;
 
-  useEffect(() => setIsOptionsDisabled(hasUserInput), [hasUserInput, setIsOptionsDisabled]);
+  useEffect(() => {
+    setIsOptionsDisabled(hasUserInput)
+  }, [hasUserInput, setIsOptionsDisabled]);
 
   const handleMinChange = useCallback(event => {
     const input = event?.target?.value;

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -123,7 +123,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   const shouldRenderApplyButton = hasUserInput && !isSelectedInAnswersState;
 
   useEffect(() => {
-    setIsOptionsDisabled(hasUserInput)
+    setIsOptionsDisabled(hasUserInput);
   }, [hasUserInput, setIsOptionsDisabled]);
 
   const handleMinChange = useCallback(event => {

--- a/tests/components/RangeInput.test.tsx
+++ b/tests/components/RangeInput.test.tsx
@@ -24,36 +24,6 @@ const mockedActions = {
   executeVerticalQuery: jest.fn()
 };
 
-const selectableFilter: SelectableFilter = {
-  selected: true,
-  fieldId: '123',
-  matcher: Matcher.Between,
-  value: 'test'
-};
-
-const filterContextValue: FiltersContextType = {
-  selectFilter: () => null,
-  applyFilters: () => null,
-  filters: []
-};
-
-const filterContextValueDisabled: FiltersContextType = {
-  selectFilter: () => null,
-  applyFilters: () => null,
-  filters: [selectableFilter]
-};
-
-const filterGroupContextValue: FilterGroupContextType = {
-  searchValue: '',
-  fieldId: '123',
-  setSearchValue: () => null,
-  getCollapseProps: null,
-  getToggleProps: null,
-  isExpanded: null,
-  isOptionsDisabled: null,
-  setIsOptionsDisabled: () => null
-};
-
 jest.mock('@yext/answers-headless-react');
 
 it('renders the correct inital state', () => {
@@ -69,18 +39,7 @@ describe('Renders correctly for min input', () => {
   beforeEach(() => {
     mockAnswersHooks({ mockedState, mockedActions });
   });
-  it('renders input value, clear, and apply option when inputing min value', async () => {
-    renderRangeInput(filterContextValue);
-    const minTextbox = screen.getAllByRole('textbox')[0];
-    userEvent.type(minTextbox, '10');
-    await waitFor(() => {
-      expect(minTextbox).toHaveValue('10');
-    });
-    expect(screen.getByText('Clear min and max')).toBeDefined();
-    expect(screen.getByText('Apply')).toBeDefined();
-  });
-
-  it('record proper values in state when applying min', async () => {
+  it('renders correctly when inputing min and applies proper values in state', async () => {
     renderRangeInput(filterContextValue);
     const actions = spyOnActions();
     const minTextbox = screen.getAllByRole('textbox')[0];
@@ -88,6 +47,8 @@ describe('Renders correctly for min input', () => {
     await waitFor(() => {
       expect(minTextbox).toHaveValue('10');
     });
+    expect(screen.getByText('Clear min and max')).toBeDefined();
+    expect(screen.getByText('Apply')).toBeDefined();
     userEvent.click(screen.getByText('Apply'));
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: 'Over 10',
@@ -122,18 +83,7 @@ describe('Renders correctly for max input', () => {
     mockAnswersHooks({ mockedState, mockedActions });
   });
 
-  it('renders input value, clear, and apply option when inputing max value', async () => {
-    renderRangeInput(filterContextValue);
-    const maxTextbox = screen.getAllByRole('textbox')[1];
-    userEvent.type(maxTextbox, '20');
-    await waitFor(() => {
-      expect(maxTextbox).toHaveValue('20');
-    });
-    expect(screen.getByText('Clear min and max')).toBeDefined();
-    expect(screen.getByText('Apply')).toBeDefined();
-  });
-
-  it('record proper values in state when applying max', async () => {
+  it('renders correctly when inputing max and applies proper values in state', async () => {
     renderRangeInput(filterContextValue);
     const actions = spyOnActions();
     const maxTextbox = screen.getAllByRole('textbox')[1];
@@ -141,6 +91,8 @@ describe('Renders correctly for max input', () => {
     await waitFor(() => {
       expect(maxTextbox).toHaveValue('20');
     });
+    expect(screen.getByText('Clear min and max')).toBeDefined();
+    expect(screen.getByText('Apply')).toBeDefined();
     userEvent.click(screen.getByText('Apply'));
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: 'Up to 20',
@@ -238,6 +190,17 @@ describe('Renders correctly for min and max inputs', () => {
 });
 
 it('renders correctly when disabled', () => {
+  const selectableFilter: SelectableFilter = {
+    selected: true,
+    fieldId: '123',
+    matcher: Matcher.Between,
+    value: 'test'
+  };
+  const filterContextValueDisabled: FiltersContextType = {
+    selectFilter: () => null,
+    applyFilters: () => null,
+    filters: [selectableFilter]
+  };
   renderRangeInput(filterContextValueDisabled);
   const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
   expect(minTextbox).toHaveAttribute('disabled');
@@ -245,11 +208,28 @@ it('renders correctly when disabled', () => {
   expect(screen.getByText('Unselect an option to enter in a range.')).toBeDefined();
 });
 
-function renderRangeInput(expectedFilterContextValue) {
+const filterGroupContextValue: FilterGroupContextType = {
+  searchValue: '',
+  fieldId: '123',
+  setSearchValue: () => null,
+  getCollapseProps: null,
+  getToggleProps: null,
+  isExpanded: null,
+  isOptionsDisabled: null,
+  setIsOptionsDisabled: () => null
+};
+
+const filterContextValue: FiltersContextType = {
+  selectFilter: () => null,
+  applyFilters: () => null,
+  filters: []
+};
+
+function renderRangeInput(filterContextValue) {
   return (
     render(
       <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={expectedFilterContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
           <RangeInput />
         </FiltersContext.Provider>
       </FilterGroupContext.Provider>)

--- a/tests/components/RangeInput.test.tsx
+++ b/tests/components/RangeInput.test.tsx
@@ -1,0 +1,296 @@
+import userEvent from '@testing-library/user-event';
+import { State } from '@yext/answers-headless-react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { RangeInput } from '../../src/components/Filters';
+import { mockAnswersHooks, spyOnActions } from '../__utils__/mocks';
+import { Matcher, SelectableFilter } from '@yext/answers-headless-react';
+import { FiltersContext, FiltersContextType } from '../../src/components/Filters/FiltersContext';
+import { FilterGroupContext, FilterGroupContextType } from '../../src/components/Filters/FilterGroupContext';
+
+const mockedState: Partial<State> = {
+  filters: {
+    static: [],
+  },
+  meta: {
+    searchType: 'vertical'
+  }
+};
+
+const mockedActions = {
+  state: mockedState,
+  setOffset: jest.fn(),
+  setFilterOption: jest.fn(),
+  resetFacets: jest.fn(),
+  executeVerticalQuery: jest.fn()
+};
+
+const selectableFilter: SelectableFilter = {
+  selected: true,
+  fieldId: '123',
+  matcher: Matcher.Between,
+  value: 'test'
+};
+
+const filterContextValue: FiltersContextType = {
+  selectFilter: () => null,
+  applyFilters: () => null,
+  filters: []
+};
+
+const filterContextValueDisabled: FiltersContextType = {
+  selectFilter: () => null,
+  applyFilters: () => null,
+  filters: [selectableFilter]
+};
+
+const filterGroupContextValue: FilterGroupContextType = {
+  searchValue: '',
+  fieldId: '123',
+  setSearchValue: () => null,
+  getCollapseProps: null,
+  getToggleProps: null,
+  isExpanded: null,
+  isOptionsDisabled: null,
+  setIsOptionsDisabled: () => null
+};
+
+jest.mock('@yext/answers-headless-react');
+
+describe('Renders correctly for min input', () => {
+  beforeEach(() => {
+    mockAnswersHooks({ mockedState, mockedActions });
+  });
+  it('renders input value, clear, and apply option when inputing min value', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const minTextbox = screen.getAllByRole('textbox')[0];
+    userEvent.type(minTextbox, '10');
+    await waitFor(() => {
+      expect(minTextbox).toHaveValue('10');
+    });
+    expect(screen.getByText('Clear min and max')).toBeDefined();
+    expect(screen.getByText('Apply')).toBeDefined();
+  });
+
+  it('record proper values in state when applying min', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const actions = spyOnActions();
+    const minTextbox = screen.getAllByRole('textbox')[0];
+    userEvent.type(minTextbox, '10');
+    await waitFor(() => {
+      expect(minTextbox).toHaveValue('10');
+    });
+    expect(screen.getByText('Apply')).toBeDefined();
+    userEvent.click(screen.getByText('Apply'));
+    expect(actions.setFilterOption).toHaveBeenCalledWith({
+      displayName: 'Over 10',
+      fieldId: '123',
+      matcher: '$between',
+      selected: true,
+      value: {
+        start: {
+          matcher: '$ge',
+          value: 10
+        },
+      }
+    });
+  });
+
+  it('renders correctly when clearing input', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const minTextbox = screen.getAllByRole('textbox')[0];
+    userEvent.type(minTextbox, '10');
+    await waitFor(() => {
+      expect(minTextbox).toHaveValue('10');
+    });
+    expect(screen.getByText('Clear min and max')).toBeDefined();
+    userEvent.click(screen.getByText('Clear min and max'));
+    expect(minTextbox).toHaveValue('');
+  });
+});
+
+describe('Renders correctly for max input', () => {
+  beforeEach(() => {
+    mockAnswersHooks({ mockedState, mockedActions });
+  });
+  it('renders input value, clear, and apply option when inputing max value', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const maxTextbox = screen.getAllByRole('textbox')[1];
+    userEvent.type(maxTextbox, '20');
+    await waitFor(() => {
+      expect(maxTextbox).toHaveValue('20');
+    });
+    expect(screen.getByText('Clear min and max')).toBeDefined();
+    expect(screen.getByText('Apply')).toBeDefined();
+  });
+
+  it('record proper values in state when applying max', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const actions = spyOnActions();
+    const maxTextbox = screen.getAllByRole('textbox')[1];
+    userEvent.type(maxTextbox, '20');
+    await waitFor(() => {
+      expect(maxTextbox).toHaveValue('20');
+    });
+    expect(screen.getByText('Apply')).toBeDefined();
+    userEvent.click(screen.getByText('Apply'));
+    expect(actions.setFilterOption).toHaveBeenCalledWith({
+      displayName: 'Up to 20',
+      fieldId: '123',
+      matcher: '$between',
+      selected: true,
+      value: {
+        end: {
+          matcher: '$le',
+          value: 20
+        },
+      }
+    });
+  });
+
+  it('renders correctly when clearing input', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const maxTextbox = screen.getAllByRole('textbox')[1];
+    userEvent.type(maxTextbox, '20');
+    await waitFor(() => {
+      expect(maxTextbox).toHaveValue('20');
+    });
+    expect(screen.getByText('Clear min and max')).toBeDefined();
+    userEvent.click(screen.getByText('Clear min and max'));
+    expect(maxTextbox).toHaveValue('');
+  });
+});
+
+describe('Renders correctly for min and max inputs', () => {
+  beforeEach(() => {
+    mockAnswersHooks({ mockedState, mockedActions });
+  });
+  it('renders input value, clear, and apply option when inputing min and max values', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
+    userEvent.type(minTextbox, '10');
+    userEvent.type(maxTextbox, '20');
+    await waitFor(() => {
+      expect(minTextbox).toHaveValue('10');
+    });
+    expect(maxTextbox).toHaveValue('20');
+    expect(screen.getByText('Clear min and max')).toBeDefined();
+    expect(screen.getByText('Apply')).toBeDefined();
+  });
+
+  it('record proper values in state when applying min and max', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const actions = spyOnActions();
+    const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
+    userEvent.type(minTextbox, '10');
+    userEvent.type(maxTextbox, '20');
+    await waitFor(() => {
+      expect(minTextbox).toHaveValue('10');
+    });
+    expect(maxTextbox).toHaveValue('20');
+    expect(screen.getByText('Apply')).toBeDefined();
+    userEvent.click(screen.getByText('Apply'));
+    expect(actions.setFilterOption).toHaveBeenCalledWith({
+      displayName: '10 - 20',
+      fieldId: '123',
+      matcher: '$between',
+      selected: true,
+      value: {
+        start: {
+          matcher: '$ge',
+          value: 10
+        },
+        end: {
+          matcher: '$le',
+          value: 20
+        },
+      }
+    });
+  });
+
+  it('renders correctly when clearing inputs', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
+    userEvent.type(minTextbox, '10');
+    userEvent.type(maxTextbox, '20');
+    await waitFor(() => {
+      expect(minTextbox).toHaveValue('10');
+    });
+    expect(maxTextbox).toHaveValue('20');
+    expect(screen.getByText('Clear min and max')).toBeDefined();
+    userEvent.click(screen.getByText('Clear min and max'));
+    expect(minTextbox).toHaveValue('');
+    expect(maxTextbox).toHaveValue('');
+  });
+
+  it('renders correctly when input range is invalid and no filter is set in state', async () => {
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={filterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>);
+    const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
+    userEvent.type(minTextbox, '20');
+    userEvent.type(maxTextbox, '10');
+    const actions = spyOnActions();
+    await waitFor(() => {
+      expect(minTextbox).toHaveValue('20');
+    });
+    expect(maxTextbox).toHaveValue('10');
+    expect(screen.getByText('Invalid range')).toBeDefined();
+    expect(actions.setFilterOption).toHaveBeenCalledTimes(0);
+  });
+});
+
+it('renders correctly when disabled', () => {
+  render(<FilterGroupContext.Provider value={filterGroupContextValue}>
+    <FiltersContext.Provider value={filterContextValueDisabled}>
+      <RangeInput />
+    </FiltersContext.Provider>
+  </FilterGroupContext.Provider>);
+});

--- a/tests/components/RangeInput.test.tsx
+++ b/tests/components/RangeInput.test.tsx
@@ -56,17 +56,21 @@ const filterGroupContextValue: FilterGroupContextType = {
 
 jest.mock('@yext/answers-headless-react');
 
+it('renders the correct inital state', () => {
+  renderRangeInput(filterContextValue);
+  const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
+  expect(minTextbox).toBeDefined();
+  expect(maxTextbox).toBeDefined();
+  expect(screen.queryByText('Clear min and max')).toBeNull();
+  expect(screen.queryByText('Apply')).toBeNull();
+});
+
 describe('Renders correctly for min input', () => {
   beforeEach(() => {
     mockAnswersHooks({ mockedState, mockedActions });
   });
   it('renders input value, clear, and apply option when inputing min value', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+    renderRangeInput(filterContextValue);
     const minTextbox = screen.getAllByRole('textbox')[0];
     userEvent.type(minTextbox, '10');
     await waitFor(() => {
@@ -77,19 +81,13 @@ describe('Renders correctly for min input', () => {
   });
 
   it('record proper values in state when applying min', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+    renderRangeInput(filterContextValue);
     const actions = spyOnActions();
     const minTextbox = screen.getAllByRole('textbox')[0];
     userEvent.type(minTextbox, '10');
     await waitFor(() => {
       expect(minTextbox).toHaveValue('10');
     });
-    expect(screen.getByText('Apply')).toBeDefined();
     userEvent.click(screen.getByText('Apply'));
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: 'Over 10',
@@ -105,21 +103,17 @@ describe('Renders correctly for min input', () => {
     });
   });
 
-  it('renders correctly when clearing input', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+  it('renders correctly when clearing input and no state is set', async () => {
+    renderRangeInput(filterContextValue);
+    const actions = spyOnActions();
     const minTextbox = screen.getAllByRole('textbox')[0];
     userEvent.type(minTextbox, '10');
     await waitFor(() => {
       expect(minTextbox).toHaveValue('10');
     });
-    expect(screen.getByText('Clear min and max')).toBeDefined();
     userEvent.click(screen.getByText('Clear min and max'));
     expect(minTextbox).toHaveValue('');
+    expect(actions.setFilterOption).toHaveBeenCalledTimes(0);
   });
 });
 
@@ -127,13 +121,9 @@ describe('Renders correctly for max input', () => {
   beforeEach(() => {
     mockAnswersHooks({ mockedState, mockedActions });
   });
+
   it('renders input value, clear, and apply option when inputing max value', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+    renderRangeInput(filterContextValue);
     const maxTextbox = screen.getAllByRole('textbox')[1];
     userEvent.type(maxTextbox, '20');
     await waitFor(() => {
@@ -144,19 +134,13 @@ describe('Renders correctly for max input', () => {
   });
 
   it('record proper values in state when applying max', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+    renderRangeInput(filterContextValue);
     const actions = spyOnActions();
     const maxTextbox = screen.getAllByRole('textbox')[1];
     userEvent.type(maxTextbox, '20');
     await waitFor(() => {
       expect(maxTextbox).toHaveValue('20');
     });
-    expect(screen.getByText('Apply')).toBeDefined();
     userEvent.click(screen.getByText('Apply'));
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: 'Up to 20',
@@ -172,21 +156,17 @@ describe('Renders correctly for max input', () => {
     });
   });
 
-  it('renders correctly when clearing input', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+  it('renders correctly when clearing input and no state is set', async () => {
+    renderRangeInput(filterContextValue);
+    const actions = spyOnActions();
     const maxTextbox = screen.getAllByRole('textbox')[1];
     userEvent.type(maxTextbox, '20');
     await waitFor(() => {
       expect(maxTextbox).toHaveValue('20');
     });
-    expect(screen.getByText('Clear min and max')).toBeDefined();
     userEvent.click(screen.getByText('Clear min and max'));
     expect(maxTextbox).toHaveValue('');
+    expect(actions.setFilterOption).toHaveBeenCalledTimes(0);
   });
 });
 
@@ -194,31 +174,9 @@ describe('Renders correctly for min and max inputs', () => {
   beforeEach(() => {
     mockAnswersHooks({ mockedState, mockedActions });
   });
-  it('renders input value, clear, and apply option when inputing min and max values', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
-    const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
-    userEvent.type(minTextbox, '10');
-    userEvent.type(maxTextbox, '20');
-    await waitFor(() => {
-      expect(minTextbox).toHaveValue('10');
-    });
-    expect(maxTextbox).toHaveValue('20');
-    expect(screen.getByText('Clear min and max')).toBeDefined();
-    expect(screen.getByText('Apply')).toBeDefined();
-  });
 
-  it('record proper values in state when applying min and max', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+  it('renders correctly when inputing range and applies proper values in state', async () => {
+    renderRangeInput(filterContextValue);
     const actions = spyOnActions();
     const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
     userEvent.type(minTextbox, '10');
@@ -228,6 +186,7 @@ describe('Renders correctly for min and max inputs', () => {
     });
     expect(maxTextbox).toHaveValue('20');
     expect(screen.getByText('Apply')).toBeDefined();
+    expect(screen.getByText('Clear min and max')).toBeDefined();
     userEvent.click(screen.getByText('Apply'));
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: '10 - 20',
@@ -247,13 +206,9 @@ describe('Renders correctly for min and max inputs', () => {
     });
   });
 
-  it('renders correctly when clearing inputs', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+  it('renders correctly when clearing inputs and no state is set', async () => {
+    renderRangeInput(filterContextValue);
+    const actions = spyOnActions();
     const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
     userEvent.type(minTextbox, '10');
     userEvent.type(maxTextbox, '20');
@@ -261,19 +216,14 @@ describe('Renders correctly for min and max inputs', () => {
       expect(minTextbox).toHaveValue('10');
     });
     expect(maxTextbox).toHaveValue('20');
-    expect(screen.getByText('Clear min and max')).toBeDefined();
     userEvent.click(screen.getByText('Clear min and max'));
     expect(minTextbox).toHaveValue('');
     expect(maxTextbox).toHaveValue('');
+    expect(actions.setFilterOption).toHaveBeenCalledTimes(0);
   });
 
   it('renders correctly when input range is invalid and no filter is set in state', async () => {
-    render(
-      <FilterGroupContext.Provider value={filterGroupContextValue}>
-        <FiltersContext.Provider value={filterContextValue}>
-          <RangeInput />
-        </FiltersContext.Provider>
-      </FilterGroupContext.Provider>);
+    renderRangeInput(filterContextValue);
     const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
     userEvent.type(minTextbox, '20');
     userEvent.type(maxTextbox, '10');
@@ -288,9 +238,20 @@ describe('Renders correctly for min and max inputs', () => {
 });
 
 it('renders correctly when disabled', () => {
-  render(<FilterGroupContext.Provider value={filterGroupContextValue}>
-    <FiltersContext.Provider value={filterContextValueDisabled}>
-      <RangeInput />
-    </FiltersContext.Provider>
-  </FilterGroupContext.Provider>);
+  renderRangeInput(filterContextValueDisabled);
+  const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');
+  expect(minTextbox).toHaveAttribute('disabled');
+  expect(maxTextbox).toHaveAttribute('disabled');
+  expect(screen.getByText('Unselect an option to enter in a range.')).toBeDefined();
 });
+
+function renderRangeInput(expectedFilterContextValue) {
+  return (
+    render(
+      <FilterGroupContext.Provider value={filterGroupContextValue}>
+        <FiltersContext.Provider value={expectedFilterContextValue}>
+          <RangeInput />
+        </FiltersContext.Provider>
+      </FilterGroupContext.Provider>)
+  );
+}

--- a/tests/components/SpellCheck.test.tsx
+++ b/tests/components/SpellCheck.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
 import { SpellCheck } from '../../src/components/SpellCheck';
-import { Source, State } from '@yext/answers-headless-react';
+import { State } from '@yext/answers-headless-react';
 import { mockAnswersHooks, spyOnActions } from '../__utils__/mocks';
 import userEvent from '@testing-library/user-event';
 

--- a/tests/components/SpellCheck.test.tsx
+++ b/tests/components/SpellCheck.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
 import { SpellCheck } from '../../src/components/SpellCheck';
-import { State } from '@yext/answers-headless-react';
+import { Source, State } from '@yext/answers-headless-react';
 import { mockAnswersHooks, spyOnActions } from '../__utils__/mocks';
 import userEvent from '@testing-library/user-event';
 


### PR DESCRIPTION
This PR adds Jest tests for RangeInput component. Tests were not passing in the first commit because of an error in useEffect function of RangeInput - instead of returning nothing, it returned a non-function.

J=SLAP-2145
TEST=auto