### PR TITLE
Consistent naming for CssClass interface containers

### DIFF
--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -14,8 +14,8 @@ import { useStateUpdatedOnSearch } from '../hooks/useStateUpdatedOnSearch';
  * @public
  */
 export interface AppliedFiltersCssClasses {
-  appliedFiltersContainer?: string,
-  appliedFiltersContainer___loading?: string,
+  container?: string,
+  container___loading?: string,
   nlpFilter?: string,
   removableFilter?: string,
   removeFilterButton?: string,
@@ -25,8 +25,8 @@ export interface AppliedFiltersCssClasses {
 
 export const builtInCssClasses: Readonly<AppliedFiltersCssClasses> = {
   // Use negative margin to remove space above the filters on mobile
-  appliedFiltersContainer: 'flex flex-wrap -mt-3 md:mt-0 mb-2',
-  appliedFiltersContainer___loading: 'opacity-50',
+  container: 'flex flex-wrap -mt-3 md:mt-0 mb-2',
+  container___loading: 'opacity-50',
   nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium text-neutral-dark mr-2 mb-2',
   removableFilter: 'flex items-center border rounded-3xl px-3 py-1.5 text-sm font-medium text-neutral-dark mr-2 mb-2',
   removeFilterButton: 'w-2 h-2 text-neutral m-1.5',
@@ -90,8 +90,8 @@ export function AppliedFilters(props: AppliedFiltersProps): JSX.Element {
   ]);
 
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
-  cssClasses.appliedFiltersContainer = classNames(cssClasses.appliedFiltersContainer, {
-    [cssClasses.appliedFiltersContainer___loading ?? '']: isLoading
+  cssClasses.container = classNames(cssClasses.container, {
+    [cssClasses.container___loading ?? '']: isLoading
   });
   return <AppliedFiltersDisplay
     {...appliedFilters}

--- a/src/components/AppliedFiltersDisplay.tsx
+++ b/src/components/AppliedFiltersDisplay.tsx
@@ -126,7 +126,7 @@ export function AppliedFiltersDisplay(props: AppliedFiltersDisplayProps): JSX.El
 
   const hasRemovableFilters = (staticFilters.length + facets.length + hierarchicalFacets.length) > 0;
   return (
-    <div className={cssClasses.appliedFiltersContainer} aria-label='Applied filters to current search'>
+    <div className={cssClasses.container} aria-label='Applied filters to current search'>
       {nlpFilters.map(filter =>
         <NlpFilter filter={filter} key={filter.displayName} cssClasses={cssClasses} />
       )}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -28,8 +28,8 @@ export interface PaginationProps {
  * @public
  */
 export interface PaginationCssClasses {
-  paginationContainer?: string,
-  paginationContainer___loading?: string,
+  container?: string,
+  container___loading?: string,
   labelContainer?: string,
   label?: string,
   selectedLabel?: string,
@@ -39,8 +39,8 @@ export interface PaginationCssClasses {
 }
 
 const builtInPaginationCssClasses: Readonly<PaginationCssClasses> = {
-  paginationContainer: 'flex justify-center mb-4',
-  paginationContainer___loading: 'opacity-50',
+  container: 'flex justify-center mb-4',
+  container___loading: 'opacity-50',
   labelContainer: 'inline-flex shadow-sm -space-x-px',
   label: 'z-0 inline-flex items-center px-4 py-2 text-sm font-semibold border border-gray-300 text-neutral',
   selectedLabel: 'z-10 inline-flex items-center px-4 py-2 text-sm font-semibold border border-primary text-primary bg-primary-light',
@@ -87,8 +87,8 @@ export function Pagination(props: PaginationProps): JSX.Element | null {
   }
 
   const paginationLabels: string[] = generatePaginationLabels(currentPageNumber, maxPageCount);
-  const paginationContainerClassNames = classNames(cssClasses.paginationContainer, {
-    [cssClasses.paginationContainer___loading ?? '']: isLoading
+  const paginationContainerClassNames = classNames(cssClasses.container, {
+    [cssClasses.container___loading ?? '']: isLoading
   });
 
   return (

--- a/src/components/ResultsCount.tsx
+++ b/src/components/ResultsCount.tsx
@@ -14,8 +14,8 @@ import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
  * @public
  */
 export interface ResultsCountCssClasses {
-  resultCountText?: string,
-  resultCountText___loading?: string
+  container?: string,
+  container___loading?: string
 }
 
 /**
@@ -29,8 +29,8 @@ export interface ResultsCountProps {
 }
 
 const builtInCssClasses: Readonly<ResultsCountCssClasses> = {
-  resultCountText: 'font-semibold text-neutral mb-4 py-2 mr-2.5',
-  resultCountText___loading: 'opacity-50'
+  container: 'font-semibold text-neutral mb-4 py-2 mr-2.5',
+  container___loading: 'opacity-50'
 };
 
 /**
@@ -45,8 +45,8 @@ export function ResultsCount({ customCssClasses }: ResultsCountProps): JSX.Eleme
   const isLoading = useAnswersState(state => state.searchStatus.isLoading);
   const resultsCountText = useResultsCount();
 
-  const resultsCountClassnames = classNames(cssClasses.resultCountText, {
-    [cssClasses.resultCountText___loading ?? '']: isLoading
+  const resultsCountClassnames = classNames(cssClasses.container, {
+    [cssClasses.container___loading ?? '']: isLoading
   });
   return <div className={resultsCountClassnames}>{resultsCountText}</div>;
 }

--- a/src/components/SpellCheck.tsx
+++ b/src/components/SpellCheck.tsx
@@ -11,15 +11,15 @@ import { executeSearch } from '../utils/search-operations';
  */
 export interface SpellCheckCssClasses {
   container?: string,
+  container___loading?: string,
   helpText?: string,
-  spellCheck___loading?: string,
   link?: string
 }
 
 const builtInCssClasses: Readonly<SpellCheckCssClasses> = {
   container: 'text-lg pb-3',
+  container___loading: 'opacity-50',
   helpText: 'text-neutral',
-  spellCheck___loading: 'opacity-50',
   link: 'text-primary font-bold hover:underline focus:underline'
 };
 
@@ -52,7 +52,7 @@ export function SpellCheck({
   const correctedQuery = useAnswersState(state => state.spellCheck.correctedQuery) ?? '';
   const isLoading = useAnswersState(state => state.searchStatus.isLoading);
   const containerClassNames = classNames(cssClasses.container, {
-    [cssClasses.spellCheck___loading ?? '']: isLoading
+    [cssClasses.container___loading ?? '']: isLoading
   });
   const answersActions = useAnswersActions();
   const handleClickSuggestion = useCallback(() => {

--- a/src/components/ThumbsFeedback.tsx
+++ b/src/components/ThumbsFeedback.tsx
@@ -16,7 +16,7 @@ export type FeedbackType = 'THUMBS_UP' | 'THUMBS_DOWN';
  * @public
  */
 export interface ThumbsFeedbackCssClasses {
-  container?: string,
+  feedbackButtonsContainer?: string,
   thumbsUpIcon?: string,
   thumbsDownIcon?: string
 }
@@ -38,7 +38,7 @@ export interface ThumbsFeedbackProps {
 }
 
 export const builtInCssClasses: Readonly<ThumbsFeedbackCssClasses> = {
-  container: 'flex justify-end mt-2 text-sm text-gray-500 font-medium',
+  feedbackButtonsContainer: 'flex justify-end mt-2 text-sm text-gray-500 font-medium',
   thumbsUpIcon: 'ml-3 w-5',
   thumbsDownIcon: 'w-5 ml-1 transform rotate-180'
 };
@@ -77,7 +77,7 @@ export function ThumbsFeedback(props: ThumbsFeedbackProps): JSX.Element {
   }, [query]);
 
   return (
-    <div className={cssClasses.container}>
+    <div className={cssClasses.feedbackButtonsContainer}>
       {isFeedbackProvided
         ? feedbackTextOnSubmission
         : <>

--- a/src/components/ThumbsFeedback.tsx
+++ b/src/components/ThumbsFeedback.tsx
@@ -16,7 +16,7 @@ export type FeedbackType = 'THUMBS_UP' | 'THUMBS_DOWN';
  * @public
  */
 export interface ThumbsFeedbackCssClasses {
-  feedbackButtonsContainer?: string,
+  container?: string,
   thumbsUpIcon?: string,
   thumbsDownIcon?: string
 }
@@ -38,7 +38,7 @@ export interface ThumbsFeedbackProps {
 }
 
 export const builtInCssClasses: Readonly<ThumbsFeedbackCssClasses> = {
-  feedbackButtonsContainer: 'flex justify-end mt-2 text-sm text-gray-500 font-medium',
+  container: 'flex justify-end mt-2 text-sm text-gray-500 font-medium',
   thumbsUpIcon: 'ml-3 w-5',
   thumbsDownIcon: 'w-5 ml-1 transform rotate-180'
 };
@@ -77,7 +77,7 @@ export function ThumbsFeedback(props: ThumbsFeedbackProps): JSX.Element {
   }, [query]);
 
   return (
-    <div className={cssClasses.feedbackButtonsContainer}>
+    <div className={cssClasses.container}>
       {isFeedbackProvided
         ? feedbackTextOnSubmission
         : <>

--- a/src/components/UniversalResults.tsx
+++ b/src/components/UniversalResults.tsx
@@ -16,12 +16,12 @@ import { VerticalConfigMap } from '../models/verticalConfig';
  */
 export interface UniversalResultsCssClasses extends SectionHeaderCssClasses {
   container?: string,
-  results___loading?: string
+  container___loading?: string
 }
 
 const builtInCssClasses: Readonly<UniversalResultsCssClasses> = {
   container: 'space-y-8',
-  results___loading: 'opacity-50',
+  container___loading: 'opacity-50',
   ...sectionHeaderCssClasses
 };
 
@@ -62,7 +62,7 @@ export function UniversalResults({
   }
 
   const resultsClassNames = classNames(cssClasses.container, {
-    [cssClasses.results___loading ?? '']: isLoading
+    [cssClasses.container___loading ?? '']: isLoading
   });
 
   return (

--- a/src/components/VerticalResults.tsx
+++ b/src/components/VerticalResults.tsx
@@ -9,8 +9,8 @@ import { Pagination, PaginationCssClasses } from './Pagination';
  * @public
  */
 export interface VerticalResultsCssClasses extends PaginationCssClasses {
-  results?: string,
-  results___loading?: string
+  container?: string,
+  container___loading?: string
 }
 
 /**

--- a/src/components/VerticalResultsDisplay.tsx
+++ b/src/components/VerticalResultsDisplay.tsx
@@ -5,7 +5,7 @@ import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import classNames from 'classnames';
 
 const builtInCssClasses: Readonly<VerticalResultsCssClasses> = {
-  results___loading: 'opacity-50'
+  container___loading: 'opacity-50'
 };
 
 interface VerticalResultsDisplayProps {
@@ -34,8 +34,8 @@ export function VerticalResultsDisplay(props: VerticalResultsDisplayProps): JSX.
     return null;
   }
 
-  const resultsClassNames = classNames(cssClasses.results, {
-    [cssClasses.results___loading ?? '']: isLoading
+  const resultsClassNames = classNames(cssClasses.container, {
+    [cssClasses.container___loading ?? '']: isLoading
   });
 
   return (


### PR DESCRIPTION
Names for styles for component containers and container loading in CSS class interfaces were inconsistent between components.  To increase consistency, they were renamed to the standard `container` and `container___loading`.  See the following slack thread for information.

https://yext.slack.com/archives/C032CKFARGS/p1655911645857069 

J=SLAP-2172
TEST=auto

Storybook will validate that no visual changes have been made.