### PR TITLE
added hover styling to "option"

### DIFF
--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -30,7 +30,7 @@ const builtInCssClasses: Readonly<FilterSearchCssClasses> = {
   inputElement: 'text-sm bg-white outline-none h-9 w-full p-2 rounded-md border border-gray-300 focus:border-primary text-neutral-dark placeholder:text-neutral',
   sectionLabel: 'text-sm text-neutral-dark font-semibold pb-2',
   focusedOption: 'bg-gray-100',
-  option: 'text-sm text-neutral-dark pb-1 cursor-pointer'
+  option: 'text-sm text-neutral-dark pb-1 cursor-pointer hover:bg-gray-100'
 };
 
 /**


### PR DESCRIPTION
This PR makes hovering over filter search autocomplete suggestions trigger a highlight on the selected option.  The JIRA item requested that the `focusedOption` CSS should be applied to options that are hovered over.  However, adding a `hover` style to `option` more closely replicates what is done in `SearchBar` and seems to be a more straightforward approach.

![image](https://user-images.githubusercontent.com/59857107/176006250-b85fd1b5-dc28-46e9-8b57-82eab0e9d2c8.png)

![image](https://user-images.githubusercontent.com/59857107/176006354-73230ca7-3617-433a-b6d9-13d7ce668280.png)

(Unfortunately screenshots do not show cursors.  Cursor is over 'first name 1', not selected with arrow keys.)

J=SLAP-2179
TEST=manual

Attempted to add hovering test to storybook, but ran into issues with simulating hover.
