### PR TITLE
Update a few import statements and types

### DIFF
--- a/src/hooks/useSearchWithNearMeHandling.ts
+++ b/src/hooks/useSearchWithNearMeHandling.ts
@@ -1,8 +1,7 @@
-import { useAnswersActions } from '@yext/answers-headless-react';
+import { useAnswersActions, AutocompleteResponse, SearchIntent } from '@yext/answers-headless-react';
 import { executeSearch, executeAutocomplete } from '../utils/search-operations';
 import { updateLocationIfNeeded } from '../utils/location-operations';
 import { MutableRefObject, useRef } from 'react';
-import { AutocompleteResponse, SearchIntent } from '@yext/answers-headless-react';
 import { onSearchFunc } from '../components/SearchBar';
 
 /** The type of a function for executing a query and returning a promise. @public */

--- a/src/utils/filterutils.tsx
+++ b/src/utils/filterutils.tsx
@@ -1,6 +1,5 @@
-import { NearFilterValue, Filter, SelectableFilter, NumberRangeValue, Matcher } from '@yext/answers-headless-react';
+import { NearFilterValue, Filter, SelectableFilter, NumberRangeValue, Matcher, AnswersActions } from '@yext/answers-headless-react';
 import isEqual from 'lodash/isEqual';
-import { AnswersHeadless } from '@yext/answers-headless-react';
 import { isNumberRangeFilter } from '../models/NumberRangeFilter';
 
 /**
@@ -87,7 +86,7 @@ function parseNumber(num: string) {
 /**
  * Deselects the selected static number range filters in state.
  */
-export function clearStaticRangeFilters(answersActions: AnswersHeadless){
+export function clearStaticRangeFilters(answersActions: AnswersActions){
   const selectedStaticRangeFilters = answersActions.state?.filters?.static?.filter(filter =>
     isNumberRangeFilter(filter) && filter.selected === true
   );


### PR DESCRIPTION
Consolidate the import statements from Headless-React since there were multiple in `useSearchWithNearMeHandling` and `filterutils.ts`. Change the `clearStaticRangeFilters` function's `answersActions` param type from `AnswersHeadless` to `AnswersActions` in`filterutils.ts`.

J=SLAP-2189
TEST=auto

Check that tests still pass and that calls to `clearStaticRangeFilters` are unchanged.