### PR TITLE
Use linting workflow from reusable workflow

### DIFF
--- a/.github/workflows/run-linting.yml
+++ b/.github/workflows/run-linting.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   linting:
-    uses: yext/slapshot-reusable-workflows/.github/workflows/run-linting.yml@run_linting
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run-linting.yml@v1

--- a/.github/workflows/run-linting.yml
+++ b/.github/workflows/run-linting.yml
@@ -7,11 +7,4 @@ on:
 
 jobs:
   linting:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-      - run: npm ci
-      - run: npm run lint
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run-linting.yml@run_linting

--- a/.github/workflows/run-linting.yml
+++ b/.github/workflows/run-linting.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   linting:
-    uses: yext/slapshot-reusable-workflows/.github/workflows/run-linting.yml@v1
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run-linting.yml@run_linting


### PR DESCRIPTION
This PR replaces actions in the linter workflow with reusable linting workflow in slapshot-reusable-workflows.

J=SLAP-2180
TEST=auto