### PR TITLE
add documentation for /bundle.css to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ function App() {
 export default App;
 ```
 
-To use Answers React Components stylesheet as an alternative to Tailwind CSS, import /bundle.css as follows:
+To use the Component Library's Styling without adding Tailwind to your project, add the following import: 
 
 ```tsx
 import '@yext/answers-react-components/bundle.css'

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ function App() {
 export default App;
 ```
 
-To use Answers React Components stylesheet, import /bundle.css as follows:
+To use Answers React Components stylesheet as an alternative to Tailwind CSS, import /bundle.css as follows:
 
 ```tsx
 import '@yext/answers-react-components/bundle.css'

--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ function App() {
 
 export default App;
 ```
+
+To use Answers React Components stylesheet, import /bundle.css as follows:
+
+```tsx
+import '@yext/answers-react-components/bundle.css'
+```


### PR DESCRIPTION
This PR adds documentation to readme for /bundle.css. 

J=SLAP-2197
TEST=manual

Tested on test-site, the styling works after removing tailwind config and importing /bundle.css.