### PR TITLE
Fix `ApplyFiltersButton` offset

### DIFF
--- a/src/components/ApplyFiltersButton.tsx
+++ b/src/components/ApplyFiltersButton.tsx
@@ -44,6 +44,7 @@ export function ApplyFiltersButton({
   const cssClasses = { ...builtInCssClasses, ...customCssClasses };
   const answersActions = useAnswersActions();
   const handleClick = useCallback(() => {
+    answersActions.setOffset(0);
     executeSearch(answersActions);
   }, [answersActions]);
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -364,7 +364,7 @@ export function SearchBar({
     || (!isVertical && filteredRecentSearches?.length) || entityPreviews);
   const screenReaderText = getScreenReaderText(
     autocompleteResponse?.results.length,
-    filteredRecentSearches?.length,
+    isVertical ? 0 : filteredRecentSearches?.length,
     entityPreviewsCount
   );
   const activeClassName = classNames('relative z-10 bg-white border rounded-3xl border-gray-200 w-full overflow-hidden', {


### PR DESCRIPTION
This PR fixes a bug where clicking the `ApplyFiltersButton` did not reset the pagination offset. Also, it includes a fix that I made in the `react-16.8` branch to only include recent searches screenreader counts when on a universal page.

J=SLAP-2202
TEST=manual

Checked that previously, navigating to the second page on the `people` vertical and selecting a filter with the apply filters button would not reset the offset, but after the fix, it resets to the first page.