### PR TITLE
Fix SearchBar stories

### DIFF
--- a/tests/components/SearchBar.stories.tsx
+++ b/tests/components/SearchBar.stories.tsx
@@ -38,19 +38,6 @@ const meta: ComponentMeta<typeof SearchBar> = {
 export default meta;
 
 export const Primary = (args: SearchBarProps) => {
-  localStorage.clear();
-  const recentSearches = [
-    {
-      query: 'recent search 2',
-      timestamp: 1656512443860
-    },
-    {
-      query: 'recent search 1',
-      timestamp: 1656512440493
-    }
-  ];
-  localStorage.setItem('__yxt_recent_searches__', JSON.stringify(recentSearches));
-
   return (
     <AnswersHeadlessContext.Provider value={generateMockedHeadless()}>
       <SearchBar {...args} />
@@ -61,12 +48,24 @@ export const Primary = (args: SearchBarProps) => {
 export const DropdownExpanded = Primary.bind({});
 DropdownExpanded.play = ({ canvasElement }) => {
   const canvas = within(canvasElement);
-  userEvent.click(canvas.getByRole('textbox'));
+  const textboxEl = canvas.getByRole('textbox');
+  conductRecentSearches(textboxEl);
+  userEvent.click(textboxEl);
 };
 
 export const DropdownHighlight = Primary.bind({});
 DropdownHighlight.play = ({ canvasElement }) => {
   const canvas = within(canvasElement);
-  userEvent.click(canvas.getByRole('textbox'));
+  const textboxEl = canvas.getByRole('textbox');
+  conductRecentSearches(textboxEl);
+  userEvent.click(textboxEl);
   userEvent.keyboard('{Tab}{Tab}{Tab}', { delay: 1 });
 };
+
+function conductRecentSearches(textboxEl: HTMLElement) {
+  userEvent.type(textboxEl, 'recent search 1');
+  userEvent.keyboard('{enter}');
+  userEvent.clear(textboxEl);
+  userEvent.type(textboxEl, 'recent search 2');
+  userEvent.keyboard('{enter}');
+}


### PR DESCRIPTION
This PR fixes the `SearchBar` stories so they display recent searches as expected. Adding recent searches manually to the browser's local storage was causing problems. This is likely because of the hard-coded timestamp, which may cause the data to be removed from storage if it is too far in the past. I changed the recent searches back to being added using `userEvent`s.

J=none
TEST=auto

See that Percy snapshots include the recent searches for `SearchBar` stories that have the dropdown expanded.