### PR TITLE
fix StaticFiltersProvider styling

### DIFF
--- a/src/components/Filters/StaticFiltersProvider.tsx
+++ b/src/components/Filters/StaticFiltersProvider.tsx
@@ -28,7 +28,7 @@ export type StaticFiltersProviderProps = PropsWithChildren<{
  */
 export function StaticFiltersProvider({
   children,
-  className = 'md-56',
+  className = 'md:w-56',
   searchOnChange = true
 }: StaticFiltersProviderProps): JSX.Element {
   const answersActions = useAnswersActions();


### PR DESCRIPTION
update className's default styling from `md-56` to `md:w-56`

J=SLAP-2207
TEST=manual

include only StaticFilters on the left hand side of people page. With `md:w-56`, see that the width of it now changes when the page size changes from >768px to <768px