### PR TITLE
fixed line break bug in resultsCount

### DIFF
--- a/src/components/ResultsCount.tsx
+++ b/src/components/ResultsCount.tsx
@@ -29,7 +29,7 @@ export interface ResultsCountProps {
 }
 
 const builtInCssClasses: Readonly<ResultsCountCssClasses> = {
-  resultsCountContainer: 'font-semibold text-neutral mb-4 py-2 mr-2.5',
+  resultsCountContainer: 'font-semibold text-neutral mb-4 py-2 mr-2.5 whitespace-nowrap',
   resultsCountLoading: 'opacity-50'
 };
 


### PR DESCRIPTION
This PR fixes the line break problem in resultsCount when the window is small and would not fit the resultsCount text and the applied filters in one line. Instead of splitting the resultCount into two lines when the window is too small, it now keeps resultsCount in one line and puts some of applied filter onto the second line.

J=SLAP-2206
TEST=manual