### PR TITLE
update docs for RenderEntityPreviews

### DIFF
--- a/docs/answers-react-components.renderentitypreviews.md
+++ b/docs/answers-react-components.renderentitypreviews.md
@@ -15,5 +15,5 @@ export declare type RenderEntityPreviews = (autocompleteLoading: boolean, vertic
 
 ## Remarks
 
-An onSubmit function is provided to allow an entity preview to be submitted.
+For the entity previews to be navigable in the search bar's dropdown section, wrap each entity preview in a [DropdownItem()](./answers-react-components.dropdownitem.md) component.
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -83,10 +83,14 @@ export interface SearchBarCssClasses extends AutocompleteResultCssClasses {
  * a map of vertical key to the corresponding VerticalResults data.
  *
  * @remarks
- * The autocomplete loading state is passed in as an optional param
+ * The autocomplete loading state is passed in as an optional param.
  *
  * @remarks
  * An onSubmit function is provided to allow an entity preview to be submitted.
+ *
+ * @remarks
+ * For the entity previews to be navigable in the search bar's dropdown section,
+ * wrap each entity preview in a {@link DropdownItem} component.
  *
  * @public
  */

--- a/test-site/src/pages/UniversalPage.tsx
+++ b/test-site/src/pages/UniversalPage.tsx
@@ -19,7 +19,7 @@ const visualAutocompleteConfig: VisualAutocompleteConfig = {
     headlessId: 'visual-autocomplete'
   }),
   restrictVerticals: ['people'],
-  renderEntityPreviews: (isLoading, verticalKeyToResults) => {
+  renderEntityPreviews: (isLoading, verticalKeyToResults, onSubmit) => {
     if (!verticalKeyToResults.people) {
       return null;
     }
@@ -36,8 +36,9 @@ const visualAutocompleteConfig: VisualAutocompleteConfig = {
           <DropdownItem
             value={r.name ?? ''}
             key={index + '-' + r.name}
-            className='flex flex-col mb-3 mr-4 border rounded-md p-3 text-lg'
+            className='flex flex-col mb-3 mr-4 border rounded-md p-3 text-lg hover:bg-gray-100'
             focusedClassName='flex flex-col mb-3 mr-4 border rounded-md p-3 text-lg bg-gray-100'
+            onClick={onSubmit}
           >
             {r.name}
           </DropdownItem>


### PR DESCRIPTION
Previously, for a search without any query suggestions and recent search option, if user returned JSX.element for entity previews doesn’t contain DropdownItem, this would cause calculateEntityPreviewsCount to return 0. Thus not rendering anything in dropdown. This is fixed in a merged commit when refactoring code: https://github.com/yext/answers-react-components/commit/d6bd209942bfc40be728ae14f40cca7381738980

Update documentation of RenderEntityPreviews for the expected usage of DropdownItem if user wants their entity preview to be navigable.

J=SLAP
TEST=manual

- check out previous commit of commit PR 168, and setup universal search with visual autocomplete. Clear recent searches in local storage. Input `Ryan` and see that there's no entity previews in dropdown even though it's in the network's response. Switch to the fixed commit 168 and the the latest change in main, see that entity previews are shown when inputting `Ryan`.
- Confirm that entity previews are rendered but NOT navigable without DropdownItem. 
- Wrapping results with DropdownItem, confirm I can tab through the entity previews