### PR TITLE
Fix static range filter bug

### DIFF
--- a/src/components/ApplyFiltersButton.tsx
+++ b/src/components/ApplyFiltersButton.tsx
@@ -1,5 +1,6 @@
 import { useAnswersActions } from '@yext/answers-headless-react';
 import { useCallback } from 'react';
+import { clearStaticRangeFilters, getSelectedNumericalFacetFields } from '../utils/filterutils';
 import { executeSearch } from '../utils/search-operations';
 
 /**
@@ -45,6 +46,7 @@ export function ApplyFiltersButton({
   const answersActions = useAnswersActions();
   const handleClick = useCallback(() => {
     answersActions.setOffset(0);
+    clearStaticRangeFilters(answersActions, getSelectedNumericalFacetFields(answersActions));
     executeSearch(answersActions);
   }, [answersActions]);
 

--- a/src/components/Filters/FacetsProvider.tsx
+++ b/src/components/Filters/FacetsProvider.tsx
@@ -6,7 +6,7 @@ import {
 } from '@yext/answers-headless-react';
 import { ReactNode, useMemo } from 'react';
 
-import { isNumberRangeValue } from '../../utils/filterutils';
+import { getSelectedNumericalFacetFields, isNumberRangeValue } from '../../utils/filterutils';
 import { clearStaticRangeFilters } from '../../utils/filterutils';
 import { executeSearch } from '../../utils/search-operations';
 import { FiltersContext, FiltersContextType } from './FiltersContext';
@@ -78,7 +78,7 @@ export function FacetsProvider({
       applyFilters() {
         if (searchOnChange) {
           answersActions.setOffset(0);
-          clearStaticRangeFilters(answersActions);
+          clearStaticRangeFilters(answersActions, getSelectedNumericalFacetFields(answersActions));
           executeSearch(answersActions);
         }
       },

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -2,7 +2,7 @@ import { Matcher, NumberRangeValue, useAnswersActions, useAnswersState } from '@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useFilterGroupContext } from './FilterGroupContext';
 import { useComposedCssClasses } from '../../hooks/useComposedCssClasses';
-import { findSelectableFilter, isNumberRangeValue, parseNumberRangeInput } from '../../utils/filterutils';
+import { clearStaticRangeFilters, findSelectableFilter, parseNumberRangeInput } from '../../utils/filterutils';
 import { executeSearch } from '../../utils/search-operations';
 import classNames from 'classnames';
 import { NumberRangeFilter } from '../../models/NumberRangeFilter';
@@ -142,16 +142,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
       return;
     }
     const displayName = getFilterDisplayName(rangeFilter.value);
-    // Find selected static range filters with the same fieldId
-    const selectedRangeFilters = staticFilters?.filter(filter =>
-      filter.fieldId === fieldId && filter.selected === true && isNumberRangeValue(filter.value)
-    );
-    selectedRangeFilters?.forEach(filter => {
-      answersActions.setFilterOption({
-        ...filter,
-        selected: false
-      });
-    });
+    clearStaticRangeFilters(answersActions, [fieldId]);
     answersActions.setFilterOption({
       ...rangeFilter,
       selected: true,
@@ -159,7 +150,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
     });
     answersActions.setOffset(0);
     executeSearch(answersActions);
-  }, [answersActions, fieldId, getFilterDisplayName, isValid, rangeFilter, staticFilters]);
+  }, [answersActions, fieldId, getFilterDisplayName, isValid, rangeFilter]);
 
   const handleClickClear = useCallback(() => {
     setMinRangeInput('');

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -142,7 +142,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
       return;
     }
     const displayName = getFilterDisplayName(rangeFilter.value);
-    clearStaticRangeFilters(answersActions, [fieldId]);
+    clearStaticRangeFilters(answersActions, new Set([fieldId]));
     answersActions.setFilterOption({
       ...rangeFilter,
       selected: true,

--- a/src/components/NumericalFacets.tsx
+++ b/src/components/NumericalFacets.tsx
@@ -1,9 +1,9 @@
 import { FacetsProvider, RangeInput, RangeInputCssClasses } from './Filters';
 import { FilterGroup, FilterGroupCssClasses } from './FilterGroup';
 import { Fragment } from 'react';
-import { DisplayableFacet, NumberRangeValue } from '@yext/answers-headless-react';
+import { NumberRangeValue } from '@yext/answers-headless-react';
 import { StandardFacetsProps } from './StandardFacets';
-import { isNumberRangeFilter } from '../models/NumberRangeFilter';
+import { isNumericalFacet } from '../utils/filterutils';
 
 /**
  * The CSS class interface for {@link NumericalFacets}.
@@ -86,10 +86,6 @@ export function NumericalFacets({
       }
     </FacetsProvider>
   );
-}
-
-export function isNumericalFacet(facet: DisplayableFacet): boolean {
-  return facet.options.length > 0 && isNumberRangeFilter(facet.options[0]);
 }
 
 function Divider({ className ='w-full h-px bg-gray-200 my-4' }: { className?: string }) {

--- a/src/components/NumericalFacets.tsx
+++ b/src/components/NumericalFacets.tsx
@@ -88,7 +88,7 @@ export function NumericalFacets({
   );
 }
 
-function isNumericalFacet(facet: DisplayableFacet): boolean {
+export function isNumericalFacet(facet: DisplayableFacet): boolean {
   return facet.options.length > 0 && isNumberRangeFilter(facet.options[0]);
 }
 

--- a/src/utils/filterutils.tsx
+++ b/src/utils/filterutils.tsx
@@ -1,5 +1,6 @@
 import { NearFilterValue, Filter, SelectableFilter, NumberRangeValue, Matcher, AnswersActions } from '@yext/answers-headless-react';
 import isEqual from 'lodash/isEqual';
+import { isNumericalFacet } from '../components/NumericalFacets';
 import { isNumberRangeFilter } from '../models/NumberRangeFilter';
 
 /**
@@ -84,16 +85,31 @@ function parseNumber(num: string) {
 }
 
 /**
- * Deselects the selected static number range filters in state.
+ * Deselects the selected static number range filters in state. If fieldIds are
+ * provided, only filters corresponding to one of those fieldIds are deselected.
+ * Otherwise, all selected filters are deselected.
  */
-export function clearStaticRangeFilters(answersActions: AnswersActions){
+export function clearStaticRangeFilters(answersActions: AnswersActions, fieldIds?: string[]) {
   const selectedStaticRangeFilters = answersActions.state?.filters?.static?.filter(filter =>
     isNumberRangeFilter(filter) && filter.selected === true
   );
   selectedStaticRangeFilters?.forEach(filter => {
-    answersActions.setFilterOption({
-      ...filter,
-      selected: false
-    });
+    if (!fieldIds || fieldIds.some(fieldId => fieldId === filter.fieldId)) {
+      answersActions.setFilterOption({
+        ...filter,
+        selected: false
+      });
+    }
   });
+}
+
+/**
+ * Returns an array of fieldIds of the numerical facets in state that have at
+ * least one option selected.
+ */
+export function getSelectedNumericalFacetFields(answersActions: AnswersActions): string[] {
+  const selectedNumericalFacets = answersActions.state.filters.facets?.filter(
+    f => isNumericalFacet(f) && f.options.some(o => o.selected)
+  ) ?? [];
+  return selectedNumericalFacets.map(f => f.fieldId);
 }

--- a/src/utils/filterutils.tsx
+++ b/src/utils/filterutils.tsx
@@ -16,6 +16,9 @@ export function isNumberRangeValue(obj: unknown): obj is NumberRangeValue {
   return typeof obj === 'object' && !!obj && ('start' in obj || 'end' in obj);
 }
 
+/**
+ * Checks if the facet is a numerical facet with number range filter options.
+ */
 export function isNumericalFacet(facet: DisplayableFacet): boolean {
   return facet.options.length > 0 && isNumberRangeFilter(facet.options[0]);
 }

--- a/test-site/src/pages/PeoplePage.tsx
+++ b/test-site/src/pages/PeoplePage.tsx
@@ -12,7 +12,8 @@ import {
   StandardFacets,
   HierarchicalFacets,
   ApplyFiltersButton,
-  Pagination
+  Pagination,
+  NumericalFacets
 } from '@yext/answers-react-components';
 
 const hierarchicalFacetFieldIds = ['c_hierarchicalFacet'];
@@ -28,6 +29,7 @@ export function PeoplePage() {
       <SearchBar />
       <div className='flex'>
         <div className='min-w-fit pr-4'>
+          <NumericalFacets searchOnChange={false} />
           <StandardFacets
             searchable={true}
             searchOnChange={false}
@@ -47,14 +49,14 @@ export function PeoplePage() {
             ]}
             searchOnChange={false}
           />
-          <br/>
-          <FilterSearch searchFields={[{fieldApiName: 'name', entityType: 'ce_person' }]}/>
+          <br />
+          <FilterSearch searchFields={[{ fieldApiName: 'name', entityType: 'ce_person' }]} />
           <ApplyFiltersButton />
         </div>
         <div className='flex-grow'>
           <div className='flex items-baseline'>
             <ResultsCount />
-            <AppliedFilters hierarchicalFacetsFieldIds={hierarchicalFacetFieldIds}/>
+            <AppliedFilters hierarchicalFacetsFieldIds={hierarchicalFacetFieldIds} />
           </div>
           <VerticalResults
             CardComponent={StandardCard}

--- a/test-site/src/pages/ProductsPage.tsx
+++ b/test-site/src/pages/ProductsPage.tsx
@@ -22,7 +22,7 @@ export function ProductsPage() {
       <SearchBar />
       <div className='flex'>
         <div className='min-w-fit pr-4'>
-           <NumericalFacets />
+          <NumericalFacets />
         </div>
         <div className='flex-grow'>
           <div className='flex items-baseline'>


### PR DESCRIPTION
This PR fixes a bug where range input static filters were removed when selecting/de-selecting facet options with different `fieldId`s. The expected behavior is that these static range filters are removed when conducting a new search (existing behavior), or only when a numerical facet option with the same `fieldId` is applied (fixed behavior).

J=SLAP-2213
TEST=manual

In the test-site, see that
- applying a static range filter, clearing the input, and then applying a numerical facet option for the same filter group removes the static range filter (existing behavior)
- applying a static range filter and then selecting or de-selecting a facet option from a different filter group leaves the static range filter as is (new behavior)
- conducting a new search removes facet options and static range filters, but not regular static filters (existing behavior)