### PR TITLE
add clear filter feature for 'clear min and max' button in RangeInput

### DIFF
--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -153,7 +153,6 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   }, [answersActions, fieldId, getFilterDisplayName, isValid, rangeFilter]);
 
   const handleClickClear = useCallback(() => {
-    console.log('a');
     const displayName = getFilterDisplayName(rangeFilter.value);
     clearStaticRangeFilters(answersActions, new Set([fieldId]));
     answersActions.setFilterOption({

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -153,9 +153,20 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   }, [answersActions, fieldId, getFilterDisplayName, isValid, rangeFilter]);
 
   const handleClickClear = useCallback(() => {
+    console.log('a');
+    const displayName = getFilterDisplayName(rangeFilter.value);
+    clearStaticRangeFilters(answersActions, new Set([fieldId]));
+    answersActions.setFilterOption({
+      ...rangeFilter,
+      selected: false,
+      displayName
+    });
     setMinRangeInput('');
     setMaxRangeInput('');
-  }, []);
+    answersActions.setOffset(0);
+    executeSearch(answersActions);
+  }, [answersActions, fieldId, getFilterDisplayName, isValid, rangeFilter]);
+
 
   const inputClasses = classNames(cssClasses.input, {
     [cssClasses.input___withPrefix ?? '']: !!inputPrefix,

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -154,7 +154,6 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
 
   const handleClickClear = useCallback(() => {
     const displayName = getFilterDisplayName(rangeFilter.value);
-    clearStaticRangeFilters(answersActions, new Set([fieldId]));
     answersActions.setFilterOption({
       ...rangeFilter,
       selected: false,

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -165,8 +165,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
     setMaxRangeInput('');
     answersActions.setOffset(0);
     executeSearch(answersActions);
-  }, [answersActions, fieldId, getFilterDisplayName, isValid, rangeFilter]);
-
+  }, [answersActions, fieldId, getFilterDisplayName, rangeFilter]);
 
   const inputClasses = classNames(cssClasses.input, {
     [cssClasses.input___withPrefix ?? '']: !!inputPrefix,

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -163,7 +163,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
     setMaxRangeInput('');
     answersActions.setOffset(0);
     executeSearch(answersActions);
-  }, [answersActions, fieldId, getFilterDisplayName, rangeFilter]);
+  }, [answersActions, getFilterDisplayName, rangeFilter]);
 
   const inputClasses = classNames(cssClasses.input, {
     [cssClasses.input___withPrefix ?? '']: !!inputPrefix,

--- a/tests/components/RangeInput.test.tsx
+++ b/tests/components/RangeInput.test.tsx
@@ -171,7 +171,22 @@ describe('Renders correctly for min and max inputs', () => {
     userEvent.click(screen.getByText('Clear min and max'));
     expect(minTextbox).toHaveValue('');
     expect(maxTextbox).toHaveValue('');
-    expect(actions.setFilterOption).toHaveBeenCalledTimes(0);
+    expect(actions.setFilterOption).toHaveBeenCalledWith({
+      displayName: '10 - 20',
+      fieldId: '123',
+      matcher: '$between',
+      selected: false,
+      value: {
+        start: {
+          matcher: '$ge',
+          value: 10
+        },
+        end: {
+          matcher: '$le',
+          value: 20
+        },
+      }
+    });
   });
 
   it('renders correctly when input range is invalid and no filter is set in state', async () => {

--- a/tests/components/RangeInput.test.tsx
+++ b/tests/components/RangeInput.test.tsx
@@ -64,7 +64,7 @@ describe('Renders correctly for min input', () => {
     });
   });
 
-  it('renders correctly when clearing input and no state is set', async () => {
+  it('renders correctly when clearing input and removes range filter set in state', async () => {
     renderRangeInput(filterContextValue);
     const actions = spyOnActions();
     const minTextbox = screen.getAllByRole('textbox')[0];
@@ -119,7 +119,7 @@ describe('Renders correctly for max input', () => {
     });
   });
 
-  it('renders correctly when clearing input and no state is set', async () => {
+  it('renders correctly when clearing input and removes range filter set in state', async () => {
     renderRangeInput(filterContextValue);
     const actions = spyOnActions();
     const maxTextbox = screen.getAllByRole('textbox')[1];
@@ -180,7 +180,7 @@ describe('Renders correctly for min and max inputs', () => {
     });
   });
 
-  it('renders correctly when clearing inputs and no state is set', async () => {
+  it('renders correctly when clearing inputs and removes range filter set in state', async () => {
     renderRangeInput(filterContextValue);
     const actions = spyOnActions();
     const [minTextbox, maxTextbox] = screen.getAllByRole('textbox');

--- a/tests/components/RangeInput.test.tsx
+++ b/tests/components/RangeInput.test.tsx
@@ -74,7 +74,18 @@ describe('Renders correctly for min input', () => {
     });
     userEvent.click(screen.getByText('Clear min and max'));
     expect(minTextbox).toHaveValue('');
-    expect(actions.setFilterOption).toHaveBeenCalledTimes(0);
+    expect(actions.setFilterOption).toHaveBeenCalledWith({
+      displayName: 'Over 10',
+      fieldId: '123',
+      matcher: '$between',
+      selected: false,
+      value: {
+        start: {
+          matcher: '$ge',
+          value: 10
+        },
+      }
+    });
   });
 });
 
@@ -118,7 +129,18 @@ describe('Renders correctly for max input', () => {
     });
     userEvent.click(screen.getByText('Clear min and max'));
     expect(maxTextbox).toHaveValue('');
-    expect(actions.setFilterOption).toHaveBeenCalledTimes(0);
+    expect(actions.setFilterOption).toHaveBeenCalledWith({
+      displayName: 'Up to 20',
+      fieldId: '123',
+      matcher: '$between',
+      selected: false,
+      value: {
+        end: {
+          matcher: '$le',
+          value: 20
+        },
+      }
+    });
   });
 });
 


### PR DESCRIPTION
This PR adds a 'clear filter' feature for 'clear min and max' button in RangeInput as suggested by product, so that the button does not only clear the input itself but also the range filter that is applied. The test file has also been changed so that it will check whether the range filter is cleared in state when using the clear button.

J=SLAP-2212
TEST=manual

Test: applied range input filter and clicked the clear button, it removes the applied range filter. Also tested with other applied filters, clicking on clear button for range input filter does not clear other filters as expected.