### PR TITLE
Show pagination info in results count

### DIFF
--- a/src/components/ResultsCount.tsx
+++ b/src/components/ResultsCount.tsx
@@ -7,6 +7,7 @@ import {
 import classNames from 'classnames';
 import { processTranslation } from './utils/processTranslation';
 import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
+import { min } from 'lodash';
 
 /**
  *  The CSS class interface for {@link ResultsCount}.
@@ -57,6 +58,8 @@ export function ResultsCount({ customCssClasses }: ResultsCountProps): JSX.Eleme
 function useResultsCount() {
   const isVertical = useAnswersState(state => state.meta.searchType) === SearchTypeEnum.Vertical;
   const results = useAnswersState(state => isVertical ? state.vertical : state.universal.verticals);
+  const offset = useAnswersState(state => state.vertical.offset) || 0;
+  const limit = useAnswersState(state => state.vertical.limit) || 10;
   let resultsCount = 0;
   if (results) {
     if (isUniversalSearchResults(results)) {
@@ -73,7 +76,16 @@ function useResultsCount() {
     pluralForm: `${resultsCount} Results`,
     count: resultsCount
   });
-  return resultsCountText;
+
+  if (resultsCount > (limit)){
+    const paginateStart = offset + 1;
+    const paginateEnd = min([(offset + limit), resultsCount]);
+    const paginateRange = paginateStart + '-'+ paginateEnd;
+    const resultCountWithPaginationText = paginateRange + ' of ' + resultsCountText;
+    return resultCountWithPaginationText;
+  } else {
+    return resultsCountText;
+  }
 }
 
 function isUniversalSearchResults(data: VerticalResults[] | VerticalSearchState): data is VerticalResults[] {


### PR DESCRIPTION
Currently blocked by a larger issue.  Wrong number of results are showing on the test site.  Limit should be 10, but page 1 shows results 1-20, and page 2 shows results 11-30.  Showing duplicate results.