### PR TITLE
fix layout shift issue with filter/facet components

### DIFF
--- a/src/components/Filters/FacetsProvider.tsx
+++ b/src/components/Filters/FacetsProvider.tsx
@@ -44,7 +44,7 @@ export interface FacetsProviderProps {
  */
 export function FacetsProvider({
   children,
-  className = 'md:w-56',
+  className = 'w-full',
   searchOnChange = true
 }: FacetsProviderProps): JSX.Element {
   const answersActions = useAnswersActions();

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -62,7 +62,7 @@ export interface RangeInputCssClasses {
 
 const builtInCssClasses: Readonly<RangeInputCssClasses> = {
   rangeInputContainer: 'flex flex-col',
-  input: 'w-24 h-9 form-input cursor-pointer border rounded-md focus:ring-0 text-neutral-dark text-sm appearance-none leading-9',
+  input: 'w-full h-9 form-input cursor-pointer border rounded-md focus:ring-0 text-neutral-dark text-sm appearance-none leading-9',
   input___withPrefix: 'pl-[1.375rem]',
   input___withoutPrefix: 'px-2',
   input___disabled: 'bg-gray-50 placeholder:text-neutral-light cursor-not-allowed',

--- a/src/components/Filters/StaticFiltersProvider.tsx
+++ b/src/components/Filters/StaticFiltersProvider.tsx
@@ -28,7 +28,7 @@ export type StaticFiltersProviderProps = PropsWithChildren<{
  */
 export function StaticFiltersProvider({
   children,
-  className = 'md:w-56',
+  className = 'w-full',
   searchOnChange = true
 }: StaticFiltersProviderProps): JSX.Element {
   const answersActions = useAnswersActions();

--- a/test-site/src/pages/PeoplePage.tsx
+++ b/test-site/src/pages/PeoplePage.tsx
@@ -28,7 +28,7 @@ export function PeoplePage() {
     <div>
       <SearchBar />
       <div className='flex'>
-      <div className='w-56 shrink-0 mr-5'>
+        <div className='w-56 shrink-0 mr-5'>
           <NumericalFacets searchOnChange={false} />
           <StandardFacets
             searchable={true}

--- a/test-site/src/pages/PeoplePage.tsx
+++ b/test-site/src/pages/PeoplePage.tsx
@@ -28,7 +28,7 @@ export function PeoplePage() {
     <div>
       <SearchBar />
       <div className='flex'>
-        <div className='min-w-fit pr-4'>
+      <div className='w-56 shrink-0 mr-5'>
           <NumericalFacets searchOnChange={false} />
           <StandardFacets
             searchable={true}

--- a/test-site/src/pages/ProductsPage.tsx
+++ b/test-site/src/pages/ProductsPage.tsx
@@ -21,7 +21,7 @@ export function ProductsPage() {
     <div>
       <SearchBar />
       <div className='flex'>
-        <div className='min-w-fit pr-4'>
+        <div className='w-56 shrink-0 mr-5'>
           <NumericalFacets />
         </div>
         <div className='flex-grow'>


### PR DESCRIPTION
Per product's feedback, update default width styling to be `w-full` and have user use a container element to control sizing instead. Update pages in test-site to have the div container of the filters/facets specify a fixed width.

J=SLAP-2214
TEST=manual

spin up test-site, toggle collapse/expand button on employee department facet on different screen size and see that layout remain fixed (not shifting when toggle). 