### PR TITLE
fix inputPrefix collision issue 

### DIFF
--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -62,8 +62,8 @@ export interface RangeInputCssClasses {
 
 const builtInCssClasses: Readonly<RangeInputCssClasses> = {
   rangeInputContainer: 'flex flex-col',
-  input: 'w-full h-9 form-input cursor-pointer border rounded-md focus:ring-0 text-neutral-dark text-sm appearance-none leading-9',
-  input___withPrefix: 'pl-[1.375rem]',
+  input: 'w-full h-9 form-input cursor-pointer border rounded-md focus:ring-0 text-neutral-dark text-sm text-right appearance-none leading-9',
+  input___withPrefix: 'pl-[2.5rem]',
   input___withoutPrefix: 'px-2',
   input___disabled: 'bg-gray-50 placeholder:text-neutral-light cursor-not-allowed',
   input___enabled: 'placeholder:text-neutral',


### PR DESCRIPTION
This PR fixes inputPrefix collision issue in RangeInput. The padding with inputPrefix is increased to avoid potential collision of max(min) input with the inputPrefix for up to three characters. The max/min input is also aligned to the right as approved by product.

J=SLAP-2212
TEST=manual

Tested the change by adding an inputPrefix of three characters (USD) to NumericalFacets. With padding increased, the max/min input no longer collides with inputPrefix. The min/max input was aligned to the right because of aesthetic reason approved by product - so without any input, the min/max placeholder and inputPrefix would not appear cramped together - input numbers appeared as expected with the right alignment.