### PR TITLE
fix tooltip location

### DIFF
--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -70,14 +70,14 @@ const builtInCssClasses: Readonly<RangeInputCssClasses> = {
   input___valid: 'border-gray-300 focus:border-primary',
   input___invalid: 'border-red-700 focus:border-red-700',
   inputContainer: 'relative',
-  inputRowContainer: 'flex flex-row items-center space-x-3 peer',
+  inputRowContainer: 'flex flex-row items-center space-x-3 group',
   buttonsContainer: 'flex flex-row items-center justify-between pt-2',
   inputPrefix: 'absolute left-2 top-2 text-sm',
   inputPrefix___disabled: 'text-neutral-light cursor-not-allowed',
   inputPrefix___enabled: 'text-neutral',
   applyButton: 'text-sm text-primary font-medium',
   clearButton: 'text-sm text-neutral font-medium',
-  tooltipContainer: 'invisible peer-hover:visible relative -right-60 -top-10',
+  tooltipContainer: 'invisible group-hover:visible relative -top-6',
   tooltip: 'absolute z-10 left-0 whitespace-nowrap rounded shadow-lg p-3 text-sm bg-neutral-dark text-white',
   invalidMessage: 'pl-3 text-sm text-red-700',
   invalidRowContainer: 'pt-2 flex flex-row items-center'
@@ -202,14 +202,14 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
         {renderInput(minRangeInput, handleMinChange, 'Min')}
         <div className='w-2.5 text-sm text-neutral'>-</div>
         {renderInput(maxRangeInput, handleMaxChange, 'Max')}
-      </div>
-      {isDisabled &&
+        {isDisabled &&
         <div className={cssClasses.tooltipContainer}>
           <div className={cssClasses.tooltip}>
             Unselect an option to enter in a range.
           </div>
         </div>
-      }
+        }
+      </div>
       {!isValid &&
         <div className={cssClasses.invalidRowContainer}>
           <InvalidIcon/>


### PR DESCRIPTION
with rangeInput having `w-full`, dynamic width sizing, the manual top/right position styling adjustment no longer work if user change the width of rangeInput. The tooltip would overlap with the input boxes. Updated to ensure the tooltip always snap to the end of the rangeInput box
![Screen Shot 2022-07-13 at 4 45 03 PM](https://user-images.githubusercontent.com/36055303/178831055-c8ce3d6e-abe8-4eda-82dc-01d736ae1921.png)

J=none
TEST=manual&auto

see that tooltip is placed at the end of the rangeInput box no matter the sizing
![Screen Shot 2022-07-13 at 4 47 54 PM](https://user-images.githubusercontent.com/36055303/178831551-d41ad504-f9e5-49d0-8963-f9a398bff71d.png)
![Screen Shot 2022-07-13 at 4 48 11 PM](https://user-images.githubusercontent.com/36055303/178831554-bbb3a232-f623-467b-8893-d653e791e5bc.png)
